### PR TITLE
update deployment instructions and version updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 # NFS Ganesha server and external provisioner
 
-[![Docker Repository on Quay](https://quay.io/repository/external_storage/nfs-ganesha-server-and-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/nfs-ganesha-server-and-provisioner)
-```
-quay.io/external_storage/nfs-ganesha-server-and-provisioner
-```
+`nfs-ganesha-server-and-external-provisioner` is an out-of-tree dynamic provisioner for Kubernetes 1.14+. You can use it to quickly & easily deploy shared storage that works almost anywhere. Or it can help you write your own out-of-tree dynamic provisioner by serving as an example implementation of the requirements detailed in [the proposal](https://github.com/kubernetes/kubernetes/pull/30285). 
 
-nfs-ganesha-server-and-external-provisioner is an out-of-tree dynamic provisioner for Kubernetes 1.4+. You can use it to quickly & easily deploy shared storage that works almost anywhere. Or it can help you write your own out-of-tree dynamic provisioner by serving as an example implementation of the requirements detailed in [the proposal](https://github.com/kubernetes/kubernetes/pull/30285). 
-
-It works just like in-tree dynamic provisioners: a `StorageClass` object can specify an instance of nfs-ganesha-server-and-external-provisioner to be its `provisioner` like it specifies in-tree provisioners such as GCE or AWS. Then, the instance of nfs-ganesha-server-and-external-provisioner will watch for `PersistentVolumeClaims` that ask for the `StorageClass` and automatically create NFS-backed `PersistentVolumes` for them. For more information on how dynamic provisioning works, see [the docs](http://kubernetes.io/docs/user-guide/persistent-volumes/) or [this blog post](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html).
+It works just like in-tree dynamic provisioners: a `StorageClass` object can specify an instance of `nfs-ganesha-server-and-external-provisioner` to be its `provisioner` like it specifies in-tree provisioners such as GCE or AWS. Then, the instance of nfs-ganesha-server-and-external-provisioner will watch for `PersistentVolumeClaims` that ask for the `StorageClass` and automatically create NFS-backed `PersistentVolumes` for them. For more information on how dynamic provisioning works, see [the docs](http://kubernetes.io/docs/user-guide/persistent-volumes/) or [this blog post](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html).
 
 ## Quickstart
-Choose some volume for your nfs-ganesha-server-and-external-provisioner instance to store its state & data in and mount the volume at `/export` in `deploy/kubernetes/deployment.yaml`. It doesn't have to be a `hostPath` volume, it can e.g. be a PVC. Note that the volume must have a [supported file system](https://github.com/nfs-ganesha/nfs-ganesha/wiki/Fsalsupport#vfs) on it: any local filesystem on Linux is supported & NFS is not supported.
+
+Choose some volume for your `nfs-ganesha-server-and-external-provisioner` instance to store its state & data in and mount the volume at `/export` in [deploy/kubernetes/deployment.yaml](./deploy/kubernetes/deployment.yaml). It doesn't have to be a `hostPath` volume, it can e.g. be a PVC. Note that the volume must have a [supported file system](https://github.com/nfs-ganesha/nfs-ganesha/wiki/Fsalsupport#vfs) on it: any local filesystem on Linux is supported & NFS is not supported.
+
 ```yaml
 ...
   volumeMounts:
@@ -73,17 +70,25 @@ Deleting the provisioner deployment will cause any outstanding `PersistentVolume
 
 ## Running
 
-To deploy nfs-ganesha-server-and-external-provisioner on a Kubernetes cluster see [Deployment](docs/deployment.md).
+To deploy `nfs-ganesha-server-and-external-provisioner` on a Kubernetes cluster see [Deployment](docs/deployment.md).
 
-To use nfs-ganesha-server-and-external-provisioner once it is deployed see [Usage](docs/usage.md).
+To use `nfs-ganesha-server-and-external-provisioner` once it is deployed see [Usage](docs/usage.md).
 
 ## [Changelog](CHANGELOG.md)
+
 Releases done here in external-storage will not have corresponding git tags (external-storage's git tags are reserved for versioning the library), so to keep track of releases check this README, the [changelog](CHANGELOG.md), or [Quay](https://quay.io/repository/external_storage/nfs-ganesha-server-and-provisioner)
 
 ## Writing your own
+
 Go [here](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner) for an example of how to write your own out-of-tree dynamic provisioner.
 
 ## Roadmap
+
+The source code in this repository was migrated from [kubernetes-incubator/external-storage](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs). We are yet to complete the following migration tasks. 
+- Update e2e tests
+- Automate building container images to the new registry
+- Update helm chart
+
 This is still alpha/experimental and will change to reflect the [out-of-tree dynamic provisioner proposal](https://github.com/kubernetes/kubernetes/pull/30285)
 
 ## Community, discussion, contribution, and support

--- a/deploy/kubernetes/claim.yaml
+++ b/deploy/kubernetes/claim.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: "example-nfs"
 spec:
+  storageClassName: example-nfs
   accessModes:
     - ReadWriteMany
   resources:

--- a/deploy/kubernetes/psp.yaml
+++ b/deploy/kubernetes/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: nfs-provisioner

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 # Deployment
 
 ## Getting the provisioner image
-To get the Docker image onto the machine where you want to run nfs-provisioner, you can either build it or pull the newest release from Quay. You may use the unstable `latest` tag if you wish, but all the example yamls reference the newest versioned release tag.
+To get the Docker image onto the machine where you want to run `nfs-ganesha-server-and-external-provisioner`, you can either build it or pull the newest release from Quay. You may use the unstable `latest` tag if you wish, but all the example yamls reference the newest versioned release tag.
 
 ### Building
 Building the project will only work if the project is in your `GOPATH`. Download the project into your `GOPATH` directory by using `go get` or cloning it manually.
@@ -14,6 +14,8 @@ Now build the project and the Docker image by checking out the latest release an
 
 ```
 $ cd $GOPATH/src/github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
+# Configure the location where the container image should be pushed. 
+# Example REGISTRY="quay.io/myorg/"
 $ make container
 ```
 
@@ -26,7 +28,7 @@ $ docker pull quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest
 ```
 
 ## Deploying the provisioner
-Now the Docker image is on your machine. Bring up a 1.4+ cluster if you don't have one up already.
+Now the Docker image is on your machine. Bring up a 1.14+ cluster if you don't have one up already.
 
 ```
 $ ALLOW_SECURITY_CONTEXT=true API_HOST_IP=0.0.0.0 $GOPATH/src/k8s.io/kubernetes/hack/local-up-cluster.sh
@@ -42,6 +44,8 @@ Decide how to run nfs-provisioner and follow one of the below sections. The reco
 * [Outside of Kubernetes - binary](#outside-of-kubernetes---binary)
 
 ### In Kubernetes - Deployment of 1 replica
+
+Edit the `image` location in `deploy/kubernetes/deployment.yaml` to the registry location specified while building the container.
 
 Edit the `provisioner` argument in the `args` field in `deploy/kubernetes/deployment.yaml` to be the provisioner's name you decided on.
 


### PR DESCRIPTION
Minor edits to the README and deployment instructions
to indicate that the migration tasks are still underway.

Till the new image repo is setup and images are pushed,
the `make container` needs to be customed to generate image
to a custom location and should be used with the deployment.

Also updated the minimum K8s version required to 1.14 to allow
updating the spec version for PSP and Claim.

Signed-off-by: kmova <kiran.mova@mayadata.io>