### PR TITLE
Add nfs-server-provisioner helm chart

### DIFF
--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.2.1-k8s1.12
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.3.0
+version: 0.3.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.2.1-k8s1.12
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.2.2
+appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.4.0
+version: 0.5.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.0.0
+version: 1.1.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.2.1-k8s1.12
+appVersion: 2.2.2
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.3.2
+version: 0.3.3
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,10 +2,12 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.5.0
+version: 1.0.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie
+- name: kvaps
+  email: kvapss@gmail.com
 - name: joaocc
   email: joaocc-dev@live.com
 - name: naseemkullah

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,12 +2,14 @@ apiVersion: v1
 appVersion: 2.2.2
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.3.3
+version: 0.4.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie
 - name: joaocc
   email: joaocc-dev@live.com
+- name: naseemkullah
+  email: naseem@transit.app
 home: https://github.com/kubernetes/charts/tree/master/stable/nfs-server-provisioner
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.1.0
+version: 1.1.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: 1.0.8
+description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
+name: nfs-server-provisioner
+version: 0.1.0
+maintainers:
+- name: kiall
+  email: kiall@macinnes.ie
+sources:
+- https://github.com/kubernetes-incubator/external-storage/tree/master/nfs
+keywords:
+- nfs
+- storage

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.2.0
+version: 0.2.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.1.4
+version: 0.1.5
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.0.8
+appVersion: 2.2.1-k8s1.12
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.2.4
+version: 0.3.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.1.5
+version: 0.2.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.2.3
+version: 0.2.4
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,10 +2,12 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.2.1
+version: 0.2.3
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie
+- name: joaocc
+  email: joaocc-dev@live.com
 home: https://github.com/kubernetes/charts/tree/master/stable/nfs-server-provisioner
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.1.1
+version: 0.1.2
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.1.3
+version: 0.1.4
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.1.2
+version: 0.1.3
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.1.0
+version: 0.1.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie
+home: https://github.com/kubernetes/charts/tree/master/stable/nfs-server-provisioner
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs
 keywords:

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -12,9 +12,9 @@ maintainers:
   email: joaocc-dev@live.com
 - name: naseemkullah
   email: naseem@transit.app
-home: https://github.com/kubernetes/charts/tree/master/stable/nfs-server-provisioner
+home: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
 sources:
-- https://github.com/kubernetes-incubator/external-storage/tree/master/nfs
+- https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/tree/master/deploy/helm
 keywords:
 - nfs
 - storage

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -82,6 +82,7 @@ their default values.
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |
 | `tolerations`                  | List of node taints to tolerate                                                                                 | `[]`                                                     |
 | `affinity`                     | Map of node/pod affinities                                                                                      | `{}`                                                     |
+| `podSecurityContext`              | Security context settings for nfs-server-provisioner pod (see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)                                                        | `{}`                                                     |
 
 ```console
 $ helm install stable/nfs-server-provisioner --name my-release \

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -56,7 +56,7 @@ their default values.
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
 | `image.repository`             | The image repository to pull from                                                                               | `quay.io/kubernetes_incubator/nfs-provisioner`           |
-| `image.tag`                    | The image tag to pull from                                                                                      | `v1.0.8`                                                 |
+| `image.tag`                    | The image tag to pull from                                                                                      | `v2.2.2`                                                 |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |
 | `service.nfsPort`              | TCP port on which the nfs-server-provisioner NFS service is exposed                                                    | `2049`                                                   |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -62,7 +62,7 @@ their default values.
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |
 | `service.nfsPort`              | TCP port on which the nfs-server-provisioner NFS service is exposed                                                    | `2049`                                                   |
 | `service.mountdPort`           | TCP port on which the nfs-server-provisioner mountd service is exposed                                                 | `20048`                                                  |
-| `service.rpcbindPort`          | TCP port on which the nfs-server-provisioner RPC service is exposed                                                    | `51413`                                                  |
+| `service.rpcbindPort`          | TCP port on which the nfs-server-provisioner RPC service is exposed                                                    | `111`                                                    |
 | `service.nfsNodePort`          | if `service.type` is `NodePort` and this is non-empty, sets the nfs-server-provisioner node port of the NFS service    | `nil`                                                    |
 | `service.mountdNodePort`       | if `service.type` is `NodePort` and this is non-empty, sets the nfs-server-provisioner node port of the mountd service | `nil`                                                    |
 | `service.rpcbindNodePort`      | if `service.type` is `NodePort` and this is non-empty, sets the nfs-server-provisioner node port of the RPC service    | `nil`                                                    |
@@ -76,7 +76,7 @@ their default values.
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
 | `storageClass.allowVolumeExpansion` | Allow base storage PCV to be dynamically resizeable (set to null to disable )                              | `true                                                    |
 | `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `{}`                                                     |
-| `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `[ "vers=4.1", "noatime" ]`                              |
+| `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `[ "vers=3" ]`                                           |
 | `storageClass.reclaimPolicy`   | ReclaimPolicy field of the class, which can be either Delete or Retain                                          | `Delete`                                                    |
 | `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -54,6 +54,7 @@ their default values.
 
 | Parameter                      | Description                                                                                                     | Default                                                  |
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
+| `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
 | `image.repository`             | The image repository to pull from                                                                               | `quay.io/kubernetes_incubator/nfs-provisioner`           |
 | `image.tag`                    | The image tag to pull from                                                                                      | `v2.2.2`                                                 |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,200 @@
+# NFS Server Provisioner
+
+[NFS Server Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs)
+is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly
+& easily deploy shared storage that works almost anywhere.
+
+This chart will deploy the Kubernetes [external-storage projects](https://github.com/kubernetes-incubator/external-storage)
+`nfs` provisioner. This provisioner includes a built in NFS server, and is not intended for connecting to a pre-existing
+NFS server. If you have a pre-existing NFS Server, please consider using the [NFS Client Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client)
+instead.
+
+## TL;DR;
+
+```console
+$ helm install stable/nfs-server-provisioner
+```
+
+> **Warning**: While installing in the default configuration will work, any data stored on
+the dynamic volumes provisioned by this chart will not be persistent!
+
+## Introduction
+
+This chart bootstraps a [nfs-server-provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs)
+deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install stable/nfs-server-provisioner --name my-release
+```
+
+The command deploys nfs-server-provisioner on the Kubernetes cluster in the default
+configuration. The [configuration](#configuration) section lists the parameters
+that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the kibana chart and
+their default values.
+
+| Parameter                      | Description                                                                                                     | Default                                                  |
+|:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
+| `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
+| `image.repository`             | The image repository to pull from                                                                               | `quay.io/kubernetes_incubator/nfs-provisioner`           |
+| `image.tag`                    | The image tag to pull from                                                                                      | `v1.0.8`                                                 |
+| `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
+| `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |
+| `service.nfsPort`              | TCP port on which the nfs-server-provisioner NFS service is exposed                                                    | `2049`                                                   |
+| `service.mountdPort`           | TCP port on which the nfs-server-provisioner mountd service is exposed                                                 | `20048`                                                  |
+| `service.rpcbindPort`          | TCP port on which the nfs-server-provisioner RPC service is exposed                                                    | `51413`                                                  |
+| `service.nfsNodePort`          | if `service.type` is `NodePort` and this is non-empty, sets the nfs-server-provisioner node port of the NFS service    | `nil`                                                    |
+| `service.mountdNodePort`       | if `service.type` is `NodePort` and this is non-empty, sets the nfs-server-provisioner node port of the mountd service | `nil`                                                    |
+| `service.rpcbindNodePort`      | if `service.type` is `NodePort` and this is non-empty, sets the nfs-server-provisioner node port of the RPC service    | `nil`                                                    |
+| `persistence.enabled`          | Enable config persistence using PVC                                                                             | `false`                                                  |
+| `persistence.storageClass`     | PVC Storage Class for config volume                                                                             | `nil`                                                    |
+| `persistence.accessMode`       | PVC Access Mode for config volume                                                                               | `ReadWriteOnce`                                          |
+| `persistence.size`             | PVC Storage Request for config volume                                                                           | `1Gi`                                                    |
+| `storageClass.create`          | Enable creation of a StorageClass to consume this nfs-server-provisioner instance                                      | `true`                                                   |
+| `storageClass.provisionerName` | The provisioner name for the storageclass                                                                       | `cluster.local/{release-name}-{chart-name}`              |
+| `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
+| `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
+| `resources`                    | Resoure limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
+| `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |
+| `tolerations`                  | List of node taints to tolerate                                                                                 | `[]`                                                     |
+| `affinity`                     | Map of node/pod affinities                                                                                      | `{}`                                                     |
+
+```console
+$ helm install stable/nfs-server-provisioner --name my-release \
+  --set=image.tag=v1.0.8,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters
+can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/nfs-server-provisioner --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml) as an example
+
+## Persistence
+
+The nfs-server-provisioner image stores it's configuration data, and importantly, **the dynamic volumes it
+manages** `/export` path of the container.
+
+The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/)
+volume at this location. The volume can be created using dynamic volume
+provisioning. However, **it is highly recommended** to explicitly specify
+a storageclass to use rather than accept the clusters default, or pre-create
+a volume for each replica.
+
+If this chart is deployed with more than 1 replica, `storageClass.defaultClass=true`
+and `persistence.storageClass`, then the 2nd+ replica will end up using the 1st
+replica to provision storage - which is likely never a desired outcome.
+
+## Recommended Persistence Configuration Examples
+
+The following is a recommended configration example when another storage class
+exists to provide persistence:
+
+    persistence:
+      enabled: true
+      storageClass: "standard"
+      size: 200Gi
+
+    storageClass:
+      defaultClass: true
+
+On many clusters, the cloud provider integration will create a "standard" storage
+class which will create a volume (e.g. a Google Compute Engine Persistent Disk or
+Amazon EBS volume) to provide persistence.
+
+---
+
+The following is a recommended configration example when another storage class
+does not exist to provide persistence:
+
+    persistence:
+      enabled: true
+      storageClass: "-"
+      size: 200Gi
+
+    storageClass:
+      defaultClass: true
+
+In this configuration, a `PersistentVolume` must be created for each replica
+to use. Installing the Helm chart, and then inspecting the `PersistentVolumeClaim`'s
+created will provide the necessary names for your `PersistentVolume`'s to bind to.
+
+An example of the necessary `PersistentVolume`:
+
+    apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: data-nfs-server-provisioner-0
+    spec:
+      capacity:
+        storage: 200Gi
+      accessModes:
+        - ReadWriteOnce
+      gcePersistentDisk:
+        fsType: "ext4"
+        pdName: "data-nfs-server-provisioner-0"
+      claimRef:
+        namespace: kube-system
+        name: data-nfs-server-provisioner-0
+
+---
+
+The following is a recommended configration example for running on bare metal with a hostPath volume:
+
+    persistence:
+      enabled: true
+      storageClass: "-"
+      size: 200Gi
+
+    storageClass:
+      defaultClass: true
+
+    nodeSelector:
+      kubernetes.io/hostname: {node-name}
+
+In this configuration, a `PersistentVolume` must be created for each replica
+to use. Installing the Helm chart, and then inspecting the `PersistentVolumeClaim`'s
+created will provide the necessary names for your `PersistentVolume`'s to bind to.
+
+An example of the necessary `PersistentVolume`:
+
+    apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: data-nfs-server-provisioner-0
+    spec:
+      capacity:
+        storage: 200Gi
+      accessModes:
+        - ReadWriteOnce
+      hostPath:
+        path: /srv/volumes/data-nfs-server-provisioner-0
+      claimRef:
+        namespace: kube-system
+        name: data-nfs-server-provisioner-0
+
+> **Warning**: `hostPath` volumes cannot be migrated between machines by Kubernetes, as such,
+in this example, we have restricted the `nfs-server-provisioner` pod to run on a single node. This
+is unsuitable for production deployments.

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -126,7 +126,7 @@ Amazon EBS volume) to provide persistence.
 
 ---
 
-The following is a recommended configration example when another storage class
+The following is a recommended configuration example when another storage class
 does not exist to provide persistence:
 
     persistence:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -73,6 +73,7 @@ their default values.
 | `storageClass.provisionerName` | The provisioner name for the storageclass                                                                       | `cluster.local/{release-name}-{chart-name}`              |
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
+| `storageClass.allowVolumeExpansion` | Allow base storage PCV to be dynamically resizeable (set to null to disable )                              | `true                                                    |
 | `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `{}`                                                     |
 | `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `[ "vers=4.1", "noatime" ]`                              |
 | `storageClass.reclaimPolicy`   | ReclaimPolicy field of the class, which can be either Delete or Retain                                          | `Delete`                                                    |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -74,6 +74,7 @@ their default values.
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
 | `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `mountOptions: vers=4.1`                                 |
+| `storageClass.reclaimPolicy`   | ReclaimPolicy field of the class, which can be either Delete or Retain                                          | `Delete`                                                    |
 | `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |
 | `tolerations`                  | List of node taints to tolerate                                                                                 | `[]`                                                     |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -73,7 +73,8 @@ their default values.
 | `storageClass.provisionerName` | The provisioner name for the storageclass                                                                       | `cluster.local/{release-name}-{chart-name}`              |
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
-| `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `mountOptions: vers=4.1`                                 |
+| `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `{}`                                                     |
+| `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `[ "vers=4.1", "noatime" ]`                              |
 | `storageClass.reclaimPolicy`   | ReclaimPolicy field of the class, which can be either Delete or Retain                                          | `Delete`                                                    |
 | `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -73,6 +73,7 @@ their default values.
 | `storageClass.provisionerName` | The provisioner name for the storageclass                                                                       | `cluster.local/{release-name}-{chart-name}`              |
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
+| `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `mountOptions: vers=4.1`                                 |
 | `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |
 | `tolerations`                  | List of node taints to tolerate                                                                                 | `[]`                                                     |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -49,7 +49,7 @@ deletes the release.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the kibana chart and
+The following table lists the configurable parameters of the kibana chart and
 their default values.
 
 | Parameter                      | Description                                                                                                     | Default                                                  |
@@ -109,7 +109,7 @@ replica to provision storage - which is likely never a desired outcome.
 
 ## Recommended Persistence Configuration Examples
 
-The following is a recommended configration example when another storage class
+The following is a recommended configuration example when another storage class
 exists to provide persistence:
 
     persistence:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -73,7 +73,7 @@ their default values.
 | `storageClass.provisionerName` | The provisioner name for the storageclass                                                                       | `cluster.local/{release-name}-{chart-name}`              |
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
-| `resources`                    | Resoure limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
+| `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |
 | `tolerations`                  | List of node taints to tolerate                                                                                 | `[]`                                                     |
 | `affinity`                     | Map of node/pod affinities                                                                                      | `{}`                                                     |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # NFS Server Provisioner
 
-[NFS Server Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs)
+[NFS Server Provisioner](https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner)
 is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly
 & easily deploy shared storage that works almost anywhere.
 

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,0 +1,26 @@
+The NFS Provisioner service has now been installed.
+
+{{ if .Values.storageClass.create -}}
+A storage class named '{{ .Values.storageClass.name }}' has now been created
+and is available to provision dynamic volumes.
+
+You can use this storageclass by creating a `PersistentVolumeClaim` with the
+correct storageClassName attribute. For example:
+
+    ---
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: test-dynamic-volume-claim
+    spec:
+      storageClassName: "{{ .Values.storageClass.name }}"
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Mi
+
+{{ else -}}
+A storage class has NOT been created. You may create a custom `StorageClass`
+resource with a `provisioner` attribute of `{{ template "nfs-provisioner.provisionerName" . }}`.
+{{ end -}}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nfs-provisioner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nfs-provisioner.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nfs-provisioner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nfs-provisioner.provisionerName" -}}
+{{- if .Values.storageClass.provisionerName -}}
+{{- printf.Values.storageClass.provisionerName -}}
+{{- else -}}
+cluster.local/{{ template "nfs-provisioner.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Create chart name and version as used by the chart label.
 */}}
 {{- define "nfs-provisioner.provisionerName" -}}
 {{- if .Values.storageClass.provisionerName -}}
-{{- printf.Values.storageClass.provisionerName -}}
+{{- printf .Values.storageClass.provisionerName -}}
 {{- else -}}
 cluster.local/{{ template "nfs-provisioner.fullname" . -}}
 {{- end -}}

--- a/deploy/helm/templates/clusterrole.yaml
+++ b/deploy/helm/templates/clusterrole.yaml
@@ -28,4 +28,7 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["nfs-provisioner"]
     verbs: ["use"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 {{- end -}}

--- a/deploy/helm/templates/clusterrole.yaml
+++ b/deploy/helm/templates/clusterrole.yaml
@@ -1,0 +1,31 @@
+{{ if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "nfs-provisioner.fullname" . }}
+  labels:
+    app: {{ template "nfs-provisioner.name" . }}
+    chart: {{ template "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["nfs-provisioner"]
+    verbs: ["use"]
+{{- end -}}

--- a/deploy/helm/templates/rolebinding.yaml
+++ b/deploy/helm/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "nfs-provisioner.name" . }}
+    chart: {{ template "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nfs-provisioner.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nfs-provisioner.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nfs-provisioner.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nfs-provisioner.fullname" . }}
+  labels:
+    app: {{ template "nfs-provisioner.name" . }}
+    chart: {{ template "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.nfsPort }}
+      targetPort: nfs
+      protocol: TCP
+      name: nfs
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nfsNodePort))) }}
+      nodePort: {{ .Values.service.nfsNodePort }}
+{{- end }}
+    - port: {{ .Values.service.mountdPort }}
+      targetPort: mountd
+      protocol: TCP
+      name: mountd
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.mountdNodePort))) }}
+      nodePort: {{ .Values.service.mountdNodePort }}
+{{- end }}
+    - port: {{ .Values.service.rpcbindPort }}
+      targetPort: rpcbind-tcp
+      protocol: TCP
+      name: rpcbind-tcp
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rpcbindNodePort))) }}
+      nodePort: {{ .Values.service.rpcbindNodePort }}
+{{- end }}
+    - port: {{ .Values.service.rpcbindPort }}
+      targetPort: rpcbind-udp
+      protocol: UDP
+      name: rpcbind-udp
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rpcbindNodePort))) }}
+      nodePort: {{ .Values.service.rpcbindNodePort }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "nfs-provisioner.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -85,14 +85,14 @@ spec:
       protocol: TCP
       name: statd
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
-      nodePort: {{ .Values.service.statdPort }}
+      nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
     - port: {{ .Values.service.statdPort }}
       targetPort: statd-udp
       protocol: UDP
       name: statd-udp
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
-      nodePort: {{ .Values.service.statdPort }}
+      nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -14,34 +14,90 @@ spec:
       targetPort: nfs
       protocol: TCP
       name: nfs
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nfsNodePort))) }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nfsNodePort))) }}
       nodePort: {{ .Values.service.nfsNodePort }}
-{{- end }}
+      {{- end }}
+    - port: {{ .Values.service.nfsPort }}
+      targetPort: nfs-udp
+      protocol: UDP
+      name: nfs-udp
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nfsNodePort))) }}
+      nodePort: {{ .Values.service.nfsNodePort }}
+      {{- end }}
+    - port: {{ .Values.service.nlockmgrPort }}
+      targetPort: nlockmgr
+      protocol: TCP
+      name: nlockmgr
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nlockmgrNodePort))) }}
+      nodePort: {{ .Values.service.nlockmgrNodePort }}
+      {{- end }}
+    - port: {{ .Values.service.nlockmgrPort }}
+      targetPort: nlockmgr-udp
+      protocol: UDP
+      name: nlockmgr-udp
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nlockmgrPort))) }}
+      nodePort: {{ .Values.service.nlockmgrNodePort }}
+      {{- end }}
     - port: {{ .Values.service.mountdPort }}
       targetPort: mountd
       protocol: TCP
       name: mountd
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.mountdNodePort))) }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.mountdNodePort))) }}
       nodePort: {{ .Values.service.mountdNodePort }}
-{{- end }}
-    - port: {{ .Values.service.rpcbindPort }}
-      targetPort: rpcbind-tcp
+      {{- end }}
+    - port: {{ .Values.service.mountdPort }}
+      targetPort: mountd-udp
+      protocol: UDP
+      name: mountd-udp
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.mountdNodePort))) }}
+      nodePort: {{ .Values.service.mountdNodePort }}
+      {{- end }}
+    - port: {{ .Values.service.rquotadPort }}
+      targetPort: rquotad
       protocol: TCP
-      name: rpcbind-tcp
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rpcbindNodePort))) }}
+      name: rquotad
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rquotadNodePort))) }}
+      nodePort: {{ .Values.service.rquotadNodePort }}
+      {{- end }}
+    - port: {{ .Values.service.rquotadPort }}
+      targetPort: rquotad-udp
+      protocol: UDP
+      name: rquotad-udp
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rquotadNodePort))) }}
+      nodePort: {{ .Values.service.rquotadNodePort }}
+      {{- end }}
+    - port: {{ .Values.service.rpcbindPort }}
+      targetPort: rpcbind
+      protocol: TCP
+      name: rpcbind
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rpcbindNodePort))) }}
       nodePort: {{ .Values.service.rpcbindNodePort }}
-{{- end }}
+      {{- end }}
     - port: {{ .Values.service.rpcbindPort }}
       targetPort: rpcbind-udp
       protocol: UDP
       name: rpcbind-udp
-{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rpcbindNodePort))) }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.rpcbindNodePort))) }}
       nodePort: {{ .Values.service.rpcbindNodePort }}
-{{- end }}
-{{- if .Values.service.externalIPs }}
+      {{- end }}
+    - port: {{ .Values.service.statdPort }}
+      targetPort: statd
+      protocol: TCP
+      name: statd
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
+      nodePort: {{ .Values.service.statdPort }}
+      {{- end }}
+    - port: {{ .Values.service.statdPort }}
+      targetPort: statd-udp
+      protocol: UDP
+      name: statd-udp
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
+      nodePort: {{ .Values.service.statdPort }}
+      {{- end }}
+  {{- if .Values.service.externalIPs }}
   externalIPs:
-{{ toYaml .Values.service.externalIPs | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
   selector:
     app: {{ template "nfs-provisioner.name" . }}
     release: {{ .Release.Name }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "nfs-provisioner.name" . }}
+    chart: {{ template "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nfs-provisioner.fullname" . }}
+{{- end -}}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "nfs-provisioner.fullname" . }}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -99,6 +99,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -50,6 +50,9 @@ spec:
                 - SYS_RESOURCE
           args:
             - "-provisioner={{ template "nfs-provisioner.provisionerName" . }}"
+          {{- range $key, $value := .Values.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
       # NOTE: This is 10 seconds longer than the default nfs-provisioner --grace-period value of 90sec
       terminationGracePeriodSeconds: 100
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "nfs-provisioner.fullname" . }}{{ else }}{{ .Values.rbac.serviceAccountName | quote }}{{ end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -34,14 +38,38 @@ spec:
             - name: nfs
               containerPort: 2049
               protocol: TCP
+            - name: nfs-udp
+              containerPort: 2049
+              protocol: UDP
+            - name: nlockmgr
+              containerPort: 32803
+              protocol: TCP
+            - name: nlockmgr-udp
+              containerPort: 32803
+              protocol: UDP
             - name: mountd
               containerPort: 20048
               protocol: TCP
-            - name: rpcbind-tcp
+            - name: mountd-udp
+              containerPort: 20048
+              protocol: UDP
+            - name: rquotad
+              containerPort: 875
+              protocol: TCP
+            - name: rquotad-udp
+              containerPort: 875
+              protocol: UDP
+            - name: rpcbind
               containerPort: 111
               protocol: TCP
             - name: rpcbind-udp
               containerPort: 111
+              protocol: UDP
+            - name: statd
+              containerPort: 662
+              protocol: TCP
+            - name: statd-udp
+              containerPort: 662
               protocol: UDP
           securityContext:
             capabilities:
@@ -67,44 +95,43 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /export
+          {{- with .Values.resources }}
           resources:
-        {{- with .Values.resources }}
-          resources:
-{{ toYaml . | indent 12 }}
-        {{- end }}
-    {{- with .Values.nodeSelector }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
-{{- if not .Values.persistence.enabled }}
+      {{- if not .Values.persistence.enabled }}
       volumes:
         - name: data
           emptyDir: {}
-{{- end }}
+      {{- end }}
 
-{{- if .Values.persistence.enabled }}
+  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
       spec:
         accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
-      {{- if .Values.persistence.storageClass }}
-      {{- if (eq "-" .Values.persistence.storageClass) }}
+        {{- if .Values.persistence.storageClass }}
+        {{- if (eq "-" .Values.persistence.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{- else }}
         storageClassName: {{ .Values.persistence.storageClass | quote }}
-      {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-{{- end }}
+  {{- end }}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: {{ template "nfs-provisioner.fullname" . }}
+  labels:
+    app: {{ template "nfs-provisioner.name" . }}
+    chart: {{ template "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  # TODO: Investigate how/if nfs-provisioner can be scaled out beyond 1 replica
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "nfs-provisioner.name" . }}
+      release: {{ .Release.Name }}
+  serviceName: {{ template "nfs-provisioner.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "nfs-provisioner.name" . }}
+        chart: {{ template "nfs-provisioner.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    spec:
+      # NOTE: This is 10 seconds longer than the default nfs-provisioner --grace-period value of 90sec
+      terminationGracePeriodSeconds: 100
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "nfs-provisioner.fullname" . }}{{ else }}{{ .Values.rbac.serviceAccountName | quote }}{{ end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: nfs
+              containerPort: 2049
+              protocol: TCP
+            - name: mountd
+              containerPort: 20048
+              protocol: TCP
+            - name: rpcbind-tcp
+              containerPort: 111
+              protocol: TCP
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+          securityContext:
+            capabilities:
+              add:
+                - DAC_READ_SEARCH
+                - SYS_RESOURCE
+          args:
+            - "-provisioner={{ template "nfs-provisioner.provisionerName" . }}"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_NAME
+              value: {{ .Chart.Name }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: data
+              mountPath: /export
+          resources:
+        {{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+{{- if not .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+{{- end }}
+
+{{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
+      {{- if .Values.persistence.storageClass }}
+      {{- if (eq "-" .Values.persistence.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+      {{- end }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: SERVICE_NAME
-              value: {{ .Chart.Name }}
+              value: {{ template "nfs-provisioner.fullname" . }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -17,7 +17,6 @@ reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 {{ if .Values.storageClass.allowVolumeExpansion }}
 allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 {{ end }}
-{{ end -}}
 {{- with .Values.storageClass.parameters }}
 parameters:
 {{ toYaml . | indent 2 }}
@@ -26,3 +25,4 @@ parameters:
 mountOptions:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{ end -}}

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -8,10 +8,10 @@ metadata:
     chart: {{ template "nfs-provisioner.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.storageClass.defaultClass }}
+  {{- if .Values.storageClass.defaultClass }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-{{- end }}
+  {{- end }}
 provisioner: {{ template "nfs-provisioner.provisionerName" . }}
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 {{ if .Values.storageClass.allowVolumeExpansion }}
@@ -19,10 +19,10 @@ allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 {{ end }}
 {{- with .Values.storageClass.parameters }}
 parameters:
-{{ toYaml . | indent 2 }}
+{{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.storageClass.mountOptions }}
 mountOptions:
-{{ toYaml . | indent 2 }}
+{{- toYaml . | nindent 2 }}
 {{- end }}
 {{ end -}}

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.storageClass.create -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.storageClass.name }}
+  labels:
+    app: {{ template "nfs-provisioner.name" . }}
+    chart: {{ template "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.storageClass.defaultClass }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+provisioner: {{ template "nfs-provisioner.provisionerName" . }}
+{{ end -}}

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -19,3 +19,7 @@ reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{- with .Values.storageClass.mountOptions }}
+mountOptions:
+{{ toYaml . | indent 2 }}
+{{- end }}

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -14,6 +14,9 @@ metadata:
 {{- end }}
 provisioner: {{ template "nfs-provisioner.provisionerName" . }}
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+{{ if .Values.storageClass.allowVolumeExpansion }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
+{{ end }}
 {{ end -}}
 {{- with .Values.storageClass.parameters }}
 parameters:

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -13,6 +13,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 provisioner: {{ template "nfs-provisioner.provisionerName" . }}
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 {{ end -}}
 {{- with .Values.storageClass.parameters }}
 parameters:

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -14,3 +14,7 @@ metadata:
 {{- end }}
 provisioner: {{ template "nfs-provisioner.provisionerName" . }}
 {{ end -}}
+{{- with .Values.storageClass.parameters }}
+parameters:
+{{ toYaml . | indent 2 }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/kubernetes_incubator/nfs-provisioner
-  tag: v2.2.1-k8s1.12
+  tag: v2.2.2
   pullPolicy: IfNotPresent
 
 service:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -20,11 +20,17 @@ service:
   type: ClusterIP
 
   nfsPort: 2049
+  nlockmgrPort: 32803
   mountdPort: 20048
-  rpcbindPort: 51413
+  rquotadPort: 875
+  rpcbindPort: 111
+  statdPort: 662
   # nfsNodePort:
+  # nlockmgrNodePort:
   # mountdNodePort:
+  # rquotadNodePort:
   # rpcbindNodePort:
+  # statdNodePort:
 
   externalIPs: []
 
@@ -64,8 +70,7 @@ storageClass:
   parameters: {}
 
   mountOptions:
-    - vers=4.1
-    - noatime
+    - vers=3
 
   ## ReclaimPolicy field of the class, which can be either Delete or Retain
   reclaimPolicy: Delete

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -11,6 +11,11 @@ image:
   tag: v2.2.2
   pullPolicy: IfNotPresent
 
+# For a list of available arguments
+# Please see https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments
+extraArgs: {}
+  # device-based-fsids: false
+
 service:
   type: ClusterIP
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/kubernetes_incubator/nfs-provisioner
-  tag: v2.2.2
+  tag: v2.3.0
   pullPolicy: IfNotPresent
 
 # For a list of available arguments

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,76 @@
+# Default values for nfs-provisioner.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+# imagePullSecrets:
+
+image:
+  repository: quay.io/kubernetes_incubator/nfs-provisioner
+  tag: v1.0.9
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+
+  nfsPort: 2049
+  mountdPort: 20048
+  rpcbindPort: 51413
+  # nfsNodePort:
+  # mountdNodePort:
+  # rpcbindNodePort:
+
+  externalIPs: []
+
+persistence:
+  enabled: false
+
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+## For creating the StorageClass automatically:
+storageClass:
+  create: true
+
+  ## Set a provisioner name. If unset, a name will be generated.
+  # provisionerName:
+
+  ## Set StorageClass as the default StorageClass
+  ## Ignored if storageClass.create is false
+  defaultClass: false
+
+  ## Set a StorageClass name
+  ## Ignored if storageClass.create is false
+  name: nfs
+
+## For RBAC support:
+rbac:
+  create: true
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default
+
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/kubernetes_incubator/nfs-provisioner
-  tag: v1.0.9
+  tag: v2.2.1-k8s1.12
   pullPolicy: IfNotPresent
 
 service:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -53,6 +53,10 @@ storageClass:
   ## Ignored if storageClass.create is false
   name: nfs
 
+  ## StorageClass parameters
+  parameters:
+    mountOptions: vers=4.1
+
 ## For RBAC support:
 rbac:
   create: true

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -53,6 +53,8 @@ storageClass:
   ## Ignored if storageClass.create is false
   name: nfs
 
+  # set to null to prevent expansion
+  allowVolumeExpansion: true
   ## StorageClass parameters
   parameters: {}
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -54,8 +54,11 @@ storageClass:
   name: nfs
 
   ## StorageClass parameters
-  parameters:
-    mountOptions: vers=4.1
+  parameters: {}
+
+  mountOptions:
+    - vers=4.1
+    - noatime
 
   ## ReclaimPolicy field of the class, which can be either Delete or Retain
   reclaimPolicy: Delete

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -57,6 +57,9 @@ storageClass:
   parameters:
     mountOptions: vers=4.1
 
+  ## ReclaimPolicy field of the class, which can be either Delete or Retain
+  reclaimPolicy: Delete
+
 ## For RBAC support:
 rbac:
   create: true


### PR DESCRIPTION
Moving helm chart from [stable/nfs-server-provisioner](https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner) and [kvaps/nfs-server-provisioner-chart](https://github.com/kvaps/nfs-server-provisioner-chart) repositories.

All the history of commits is preserved