### PR TITLE
Refer to storageClassName over deprecated annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ kubectl create -f deploy/kubernetes/class.yaml
 storageclass "example-nfs" created
 ```
 
-Create a `PersistentVolumeClaim` with annotation `volume.beta.kubernetes.io/storage-class: "example-nfs"`
+Create a `PersistentVolumeClaim` with `storageClassName: example-nfs`.
 ```console
 $ kubectl create -f deploy/kubernetes/claim.yaml
 persistentvolumeclaim "nfs" created

--- a/deploy/kubernetes/claim.yaml
+++ b/deploy/kubernetes/claim.yaml
@@ -2,8 +2,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: nfs
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "example-nfs"
 spec:
   storageClassName: example-nfs
   accessModes:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ storageclass "example-nfs" created
 
 Now if everything is working correctly, when you create a claim requesting the class you just created, the provisioner will automatically create a volume.
 
-Edit the `volume.beta.kubernetes.io/storage-class` annotation in `deploy/kubernetes/claim.yaml` to be the name of the class. Create the claim.
+Edit `storageClassName` in `deploy/kubernetes/claim.yaml` to be the name of the class. Create the claim.
 
 ```
 $ kubectl create -f deploy/kubernetes/claim.yaml


### PR DESCRIPTION
A referenced PVC annotation with the same purpose as storageClassName
for a PVC is deprecated, this commit removes it in our kubernetes
deployments example PVC. It also updates the project's README.md and
docs/USAGE.md to reference the storageClassName rather than the
deprecated annotation.

The kubernetes documentation indicating the annotation is deprecated is
here: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class

### Note for reviewers
I have not checked removing the annotation from claim.yaml ensure things still work. I'm a novice reading up on this project and have not got down to deploying it on k8s myself yet.