### PR TITLE
grace-period: 0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -15,6 +15,7 @@ image:
 # Please see https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments
 extraArgs: {}
   # device-based-fsids: false
+  # grace-period: 0
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Up to consideration.

This setting might be quite useful to not block write requests for exiting files after server restart.
By default 90 second timeout persist to allow nfs-clients acquire their locks.