### PR TITLE
helm: support using image digest instead of tag

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.1.1
+version: 1.2.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -58,6 +58,7 @@ their default values.
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
 | `image.repository`             | The image repository to pull from                                                                               | `quay.io/kubernetes_incubator/nfs-provisioner`           |
 | `image.tag`                    | The image tag to pull from                                                                                      | `v2.2.2`                                                 |
+| `image.digest`                 | The image digest to pull, this option has precedence over `image.tag`                                           | `nil`                                                    |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |
 | `service.nfsPort`              | TCP port on which the nfs-server-provisioner NFS service is exposed                                                    | `2049`                                                   |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -57,7 +57,7 @@ their default values.
 | `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
 | `image.repository`             | The image repository to pull from                                                                               | `quay.io/kubernetes_incubator/nfs-provisioner`           |
-| `image.tag`                    | The image tag to pull from                                                                                      | `v2.2.2`                                                 |
+| `image.tag`                    | The image tag to pull                                                                                           | `v2.3.0`                                                 |
 | `image.digest`                 | The image digest to pull, this option has precedence over `image.tag`                                           | `nil`                                                    |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -32,8 +32,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.image }}
+          image: "{{ .repository }}{{ if .digest }}@{{ .digest }}{{ else }}:{{ .tag }}{{ end }}"
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
           ports:
             - name: nfs
               containerPort: 2049

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -9,6 +9,7 @@ replicaCount: 1
 image:
   repository: quay.io/kubernetes_incubator/nfs-provisioner
   tag: v2.3.0
+  # digest:
   pullPolicy: IfNotPresent
 
 # For a list of available arguments


### PR DESCRIPTION
A change as suggested by @kvaps in https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/issues/19#issuecomment-734427533.
