### PR TITLE
customize the prow build to run for adm64 only

### DIFF
--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -1,3 +1,17 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #! /bin/bash
 
 # At the moment, only amd64 builds are supported by the ./Dockerfile. 

--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#! /bin/bash
 
 # At the moment, only amd64 builds are supported by the ./Dockerfile. 
 : ${CSI_PROW_BUILD_PLATFORMS:="linux amd64"}
 
 # shellcheck disable=SC1091
-. release-tools/prow.sh
-
-gcr_cloud_build
+. release-tools/cloudbuild.sh

--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -1,1 +1,9 @@
-./release-tools/cloudbuild.sh
+#! /bin/bash
+
+# At the moment, only amd64 builds are supported by the ./Dockerfile. 
+: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64"}
+
+# shellcheck disable=SC1091
+. release-tools/prow.sh
+
+gcr_cloud_build

--- a/.prow.sh
+++ b/.prow.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#! /bin/bash
 
 # A Prow job can override these defaults, but this shouldn't be necessary.
 

--- a/.prow.sh
+++ b/.prow.sh
@@ -1,0 +1,28 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#! /bin/bash
+
+# A Prow job can override these defaults, but this shouldn't be necessary.
+
+# At the moment, only amd64 builds are supported by the ./Dockerfile. 
+: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64"}
+
+# Only these tests make sense until we can integrate k/k
+# e2es.
+: ${CSI_PROW_TESTS:="unit"}
+
+. release-tools/prow.sh
+
+main


### PR DESCRIPTION
The prow builds for windows is failing at the moment. As the current Docker file only supports
amd64, disabling the other platform builds for now. 

Ref: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/issues/6

Signed-off-by: kmova <kiran.mova@mayadata.io>