### PR TITLE
fix(dockerfile): issue with specifying binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@
 # Modified from https://github.com/rootfs/nfs-ganesha-docker by Huamin Chen
 FROM fedora:30 AS build
 
-ARG binary=./bin/nfs-provisioner
-
 # Build ganesha from source, install it to /usr/local and a use multi stage build to have a smaller image
 # Set NFS_V4_RECOV_ROOT to /export
 
@@ -49,6 +47,8 @@ RUN sed -i s/systemd// /etc/nsswitch.conf
 
 COPY --from=build /usr/local /usr/local/
 COPY --from=build /ganesha-extra /
+
+ARG binary=bin/nfs-provisioner
 COPY ${binary} /nfs-provisioner
 
 # run ldconfig after libs have been copied


### PR DESCRIPTION
When launching the canary image or by following the quick start instructions, the pod fails to start with the following error:

```
Error: failed to start container "nfs-provisioner": Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/nfs-provisioner\": permission denied": unknown
```

This is caused due to the default values set on `binary` arg (within Dockerfile) was becoming blank. 

Tested this by inserting an echo statement like below:
`RUN echo "what is set in binary: ${binary}"`

Added the echo statement after the ARG initialization and after the steps that build and copy ganesha. 
This showed the following:

```
Step 1/22 : FROM fedora:30 AS build
 ---> 177d5adf0c6c
Step 2/22 : ARG binary=bin/nfs-provisioner
 ---> Using cache
 ---> 11ff460efe07
Step 3/22 : RUN echo "what is set in binary: ${binary}"
 ---> Running in 967cd8d72245
what is set in binary: bin/nfs-provisioner
Removing intermediate container 967cd8d72245
 ---> d1fd5038fbaa
Step 4/22 : RUN dnf install -y
....
....
Step 15/22 : COPY --from=build /ganesha-extra /
 ---> Using cache
 ---> 59033fc7781c
Step 16/22 : RUN echo "what is set in binary: ${binary}"
 ---> Running in 893403bee3cb
what is set in binary: 
Removing intermediate container 893403bee3cb
 ---> 848e9c052d02
...
...

```

during the initialization of the variable and after the steps that build ganesha. 



Changed the code to set the ARG just before using it.

Signed-off-by: kmova <kiran.mova@mayadata.io>