### PR TITLE
make pod privileged, if xfs quota are enabled

### DIFF
--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -74,6 +74,11 @@ spec:
               containerPort: 662
               protocol: UDP
           securityContext:
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if and (eq $key "enable-xfs-quota") $value }}
+            privileged: true
+            {{- end }}
+            {{- end }}
             capabilities:
               add:
                 - DAC_READ_SEARCH


### PR DESCRIPTION
as mentioned in [deployment guide](https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/blob/master/docs/deployment.md) the pod running the provisioner needs to run in privileged mode, if xfs-quota is wanted.

the patch for the helm chart checks, if extraArgs enable-xfs-quota is TRUE and adds 'privileged: true' to the stateful set