### PR TITLE
Host path mount /dev/mapper with xfs_quota

### DIFF
--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -74,6 +74,11 @@ spec:
               containerPort: 662
               protocol: UDP
           securityContext:
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if and (eq $key "enable-xfs-quota") $value }}
+            privileged: true
+            {{- end }}
+            {{- end }}
             capabilities:
               add:
                 - DAC_READ_SEARCH

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -102,6 +102,12 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /export
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if and (eq $key "enable-xfs-quota") $value }}
+            - name: dev-mapper
+              mountPath: /dev/mapper
+            {{- end }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -128,7 +134,15 @@ spec:
         - name: data
           emptyDir: {}
       {{- end }}
-
+      {{- range $key, $value := .Values.extraArgs }}
+      {{- if and (eq $key "enable-xfs-quota") $value }}
+      volumes:
+        - name: dev-mapper
+          hostPath: 
+            path: /dev/mapper
+            type: Directory
+      {{- end }}        
+      {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
if xfs-quota is wanted, xfs_quota needs to access the moint point of the volume. In case, device mapper framework is used (ie logical volume is backing /export or a multipath lun wit fc or iscsi), this is something like /dev/mapper/mpatha etc.

by default, /dev/mapper in a pod does not contain any devices and therefore xfs_quota is unable to set the quota. 
this patch incl. a workaround by 'hostpath' mounting /dev/mapper into the stateful set's pod

the patch for the helm chart checks, if extraArgs enable-xfs-quota is TRUE and adds the additional mount to the stateful set.

From an security perspective, /dev/mapper/* are symlinks to /dev/dm-X, which are available already on the pod.