### PR TITLE
Migrate docker image from quay.io to gcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build
 include release-tools/build.make
 
 ifeq ($(REGISTRY),)
-	REGISTRY = quay.io/external_storage/
+	REGISTRY = gcr.io/k8s-staging-sig-storage/
 endif
 
 ifeq ($(VERSION),)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Note: This repository was migrated from https://github.com/kubernetes-incubator/
 make build
 make container
 # `nfs-provisioner:latest` will be created. 
-# To upload this to your customer registry, say `quay.io/myorg`, you can use
-# docker tag nfs-provisioner:latest quay.io/myorg/nfs-provisioner:latest
-# docker push quay.io/myorg/nfs-provisioner:latest
+# To upload this to your customer registry, say `gcr.io/myorg`, you can use
+# docker tag nfs-provisioner:latest gcr.io/myorg/nfs-provisioner:latest
+# docker push gcr.io/myorg/nfs-provisioner:latest
 ```
 
 ## Quickstart
@@ -87,7 +87,7 @@ To use `nfs-ganesha-server-and-external-provisioner` once it is deployed see [Us
 
 ## [Changelog](CHANGELOG.md)
 
-Releases done here in external-storage will not have corresponding git tags (external-storage's git tags are reserved for versioning the library), so to keep track of releases check this README, the [changelog](CHANGELOG.md), or [Quay](https://quay.io/repository/external_storage/nfs-ganesha-server-and-provisioner)
+Releases done here in external-storage will not have corresponding git tags (external-storage's git tags are reserved for versioning the library), so to keep track of releases check this README, the [changelog](CHANGELOG.md), or [GCR](https://gcr.io/k8s-staging-sig-storage/nfs-provisioner)
 
 ## Writing your own
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.3.0
+appVersion: 3.0.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.2.1
+version: 1.3.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -56,8 +56,8 @@ their default values.
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
 | `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
-| `image.repository`             | The image repository to pull from                                                                               | `quay.io/kubernetes_incubator/nfs-provisioner`           |
-| `image.tag`                    | The image tag to pull                                                                                           | `v2.3.0`                                                 |
+| `image.repository`             | The image repository to pull from                                                                               | `gcr.io/k8s-staging-sig-storage/nfs-provisioner`         |
+| `image.tag`                    | The image tag to pull                                                                                           | `v3.0.0`                                                 |
 | `image.digest`                 | The image digest to pull, this option has precedence over `image.tag`                                           | `nil`                                                    |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -7,8 +7,8 @@ replicaCount: 1
 # imagePullSecrets:
 
 image:
-  repository: quay.io/kubernetes_incubator/nfs-provisioner
-  tag: v2.3.0
+  repository: gcr.io/k8s-staging-sig-storage/nfs-provisioner
+  tag: v3.0.0
   # digest:
   pullPolicy: IfNotPresent
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccount: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest
+          image: gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
           ports:
             - name: nfs
               containerPort: 2049

--- a/deploy/kubernetes/pod.yaml
+++ b/deploy/kubernetes/pod.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccount: nfs-provisioner
   containers:
     - name: nfs-provisioner
-      image: quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest
+      image: gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
       ports:
         - name: nfs
           containerPort: 2049

--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: nfs-provisioner
-          image: quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest
+          image: gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
           ports:
             - name: nfs
               containerPort: 2049

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 # Deployment
 
 ## Getting the provisioner image
-To get the Docker image onto the machine where you want to run `nfs-ganesha-server-and-external-provisioner`, you can either build it or pull the newest release from Quay. You may use the unstable `latest` tag if you wish, but all the example yamls reference the newest versioned release tag.
+To get the Docker image onto the machine where you want to run `nfs-ganesha-server-and-external-provisioner`, you can either build it or pull the newest release from GCR. You may use the unstable `canary` tag if you wish, but all the example yamls reference the newest versioned release tag.
 
 ### Building
 Building the project will only work if the project is in your `GOPATH`. Download the project into your `GOPATH` directory by using `go get` or cloning it manually.
@@ -15,16 +15,16 @@ Now build the project and the Docker image by checking out the latest release an
 ```
 $ cd $GOPATH/src/github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
 # Configure the location where the container image should be pushed. 
-# Example REGISTRY="quay.io/myorg/"
+# Example REGISTRY="gcr.io/myorg/"
 $ make container
 ```
 
 ### Pulling
 
-If you are running in Kubernetes, it will pull the image from Quay for you. Or you can do it yourself.
+If you are running in Kubernetes, it will pull the image from GCR for you. Or you can do it yourself.
 
 ```
-$ docker pull quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest
+$ docker pull gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
 ```
 
 ## Deploying the provisioner
@@ -82,7 +82,7 @@ You may want to specify the hostname the NFS server exports from, i.e. the serve
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
 -v $HOME/.kube:/.kube:Z \
-quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest \
+gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config
 ```
@@ -90,7 +90,7 @@ or
 ```
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
-quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest \
+gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0 \
 -provisioner=example.com/nfs \
 -master=http://172.17.0.1:8080
 ```
@@ -105,7 +105,7 @@ With the two above options, the run command will look something like this.
 $ docker run --privileged \
 -v $HOME/.kube:/.kube:Z \
 -v /xfs:/export:Z \
-quay.io/external_storage/nfs-ganesha-server-and-provisioner:latest \
+gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config \
 -enable-xfs-quota=true


### PR DESCRIPTION
Update manifests to use new image location

fixes https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/issues/6

TODO:
- Use stable version tags instead of canary
- Bump Helm chart version

/hold