### PR TITLE
Add support for linux-arm64 image builds

### DIFF
--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 
-# At the moment, only amd64 builds are supported by the ./Dockerfile. 
-: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64"}
+# At the moment, only linux builds are supported by the ./Dockerfile. 
+: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64; linux arm64 -arm64"}
 
 # shellcheck disable=SC1091
 . release-tools/cloudbuild.sh

--- a/.prow.sh
+++ b/.prow.sh
@@ -17,8 +17,8 @@
 
 # A Prow job can override these defaults, but this shouldn't be necessary.
 
-# At the moment, only amd64 builds are supported by the ./Dockerfile. 
-: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64"}
+# At the moment, only linux builds are supported by the ./Dockerfile. 
+: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64; linux arm64 -arm64"}
 
 # Only these tests make sense until we can integrate k/k
 # e2es.


### PR DESCRIPTION
https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/pull/33 introduced the restriction to linux-amd64 only, and the PR description mentions it was due to Windows builds failing. To improve e2e coverage on arm64 nodes, this adds image builds for linux-arm64.