### PR TITLE
chore(doc): update references of container registry of nfs-provisioner from gcr.io to k8s.gcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build
 include release-tools/build.make
 
 ifeq ($(REGISTRY),)
-	REGISTRY = gcr.io/k8s-staging-sig-storage/
+	REGISTRY = k8s.gcr.io/sig-storage/
 endif
 
 ifeq ($(VERSION),)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build
 include release-tools/build.make
 
 ifeq ($(REGISTRY),)
-	REGISTRY = k8s.gcr.io/sig-storage/
+	REGISTRY = gcr.io/k8s-staging-sig-storage/
 endif
 
 ifeq ($(VERSION),)

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 3.0.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.3.0
+version: 1.3.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -56,7 +56,7 @@ their default values.
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
 | `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
-| `image.repository`             | The image repository to pull from                                                                               | `gcr.io/k8s-staging-sig-storage/nfs-provisioner`         |
+| `image.repository`             | The image repository to pull from                                                                               | `k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0`         |
 | `image.tag`                    | The image tag to pull                                                                                           | `v3.0.0`                                                 |
 | `image.digest`                 | The image digest to pull, this option has precedence over `image.tag`                                           | `nil`                                                    |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 # imagePullSecrets:
 
 image:
-  repository: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
+  repository: k8s.gcr.io/sig-storage/nfs-provisioner
   tag: v3.0.0
   # digest:
   pullPolicy: IfNotPresent

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 # imagePullSecrets:
 
 image:
-  repository: gcr.io/k8s-staging-sig-storage/nfs-provisioner
+  repository: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
   tag: v3.0.0
   # digest:
   pullPolicy: IfNotPresent

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccount: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
+          image: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
           ports:
             - name: nfs
               containerPort: 2049

--- a/deploy/kubernetes/pod.yaml
+++ b/deploy/kubernetes/pod.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccount: nfs-provisioner
   containers:
     - name: nfs-provisioner
-      image: gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
+      image: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
       ports:
         - name: nfs
           containerPort: 2049

--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: nfs-provisioner
-          image: gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
+          image: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
           ports:
             - name: nfs
               containerPort: 2049

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ $ make container
 If you are running in Kubernetes, it will pull the image from GCR for you. Or you can do it yourself.
 
 ```
-$ docker pull gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0
+$ docker pull k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
 ```
 
 ## Deploying the provisioner
@@ -82,7 +82,7 @@ You may want to specify the hostname the NFS server exports from, i.e. the serve
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
 -v $HOME/.kube:/.kube:Z \
-gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config
 ```
@@ -90,7 +90,7 @@ or
 ```
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
-gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0 \
 -provisioner=example.com/nfs \
 -master=http://172.17.0.1:8080
 ```
@@ -105,7 +105,7 @@ With the two above options, the run command will look something like this.
 $ docker run --privileged \
 -v $HOME/.kube:/.kube:Z \
 -v /xfs:/export:Z \
-gcr.io/k8s-staging-sig-storage/nfs-provisioner:v3.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config \
 -enable-xfs-quota=true


### PR DESCRIPTION
This PR updates the container registry references of nfs-provisioner
 from `gcr.io/k8s-staging-sig-storage` to `k8s.gcr.io/sig-storage`

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>