### PR TITLE
Update github links referencing master to reference HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Adds configurable number of retries on failed Provisioner operations. Configurable as an argument to `NewProvisionController`. nfs-provisioner defaults to 10 retries unless the new flag/argument is used. (#65)
 
 # v1.0.2
-- Usage demo & how-to for writing your own external PV provisioner added here https://github.com/kubernetes-incubator/nfs-provisioner/tree/master/demo
+- Usage demo & how-to for writing your own external PV provisioner added here https://github.com/kubernetes-incubator/nfs-provisioner/tree/HEAD/demo
 - Change behaviour for getting NFS server IP from env vars (node, service) in case POD_IP env var is not set when needed. Use `hostname -i` as a fallback only for when running out-of-cluster (#52)
 - Pass whole PVC object from controller to `Provision` as part of `VolumeOptions`, like upstream (#48)
 - Filter out controller's self-generated race-to-lock leader election PVC updates from being seen as forced resync PVC updates (#58) 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It works just like in-tree dynamic provisioners: a `StorageClass` object can specify an instance of `nfs-ganesha-server-and-external-provisioner` to be its `provisioner` like it specifies in-tree provisioners such as GCE or AWS. Then, the instance of nfs-ganesha-server-and-external-provisioner will watch for `PersistentVolumeClaims` that ask for the `StorageClass` and automatically create NFS-backed `PersistentVolumes` for them. For more information on how dynamic provisioning works, see [the docs](http://kubernetes.io/docs/user-guide/persistent-volumes/) or [this blog post](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html).
 
-Note: This repository was migrated from https://github.com/kubernetes-incubator/external-storage/tree/master/nfs. Some of the following instructions will be updated once the build and release automtion is setup. To test container image built from this repository, you will have to build and push the nfs-provisioner image using the following instructions.
+Note: This repository was migrated from https://github.com/kubernetes-incubator/external-storage/tree/HEAD/nfs. Some of the following instructions will be updated once the build and release automtion is setup. To test container image built from this repository, you will have to build and push the nfs-provisioner image using the following instructions.
 
 ```sh
 make build
@@ -91,11 +91,11 @@ Releases done here in external-storage will not have corresponding git tags (ext
 
 ## Writing your own
 
-Go [here](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner) for an example of how to write your own out-of-tree dynamic provisioner.
+Go [here](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/HEAD/examples/hostpath-provisioner) for an example of how to write your own out-of-tree dynamic provisioner.
 
 ## Roadmap
 
-The source code in this repository was migrated from [kubernetes-incubator/external-storage](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs). We are yet to complete the following migration tasks. 
+The source code in this repository was migrated from [kubernetes-incubator/external-storage](https://github.com/kubernetes-incubator/external-storage/tree/HEAD/nfs). We are yet to complete the following migration tasks.
 - Update e2e tests
 - Automate building container images to the new registry
 - Update helm chart

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   email: joaocc-dev@live.com
 home: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
 sources:
-- https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/tree/master/deploy/helm
+- https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/tree/HEAD/deploy/helm
 keywords:
 - nfs
 - storage

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -6,7 +6,7 @@ is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly
 
 This chart will deploy the Kubernetes [external-storage projects](https://github.com/kubernetes-incubator/external-storage)
 `nfs` provisioner. This provisioner includes a built in NFS server, and is not intended for connecting to a pre-existing
-NFS server. If you have a pre-existing NFS Server, please consider using the [NFS Client Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client)
+NFS server. If you have a pre-existing NFS Server, please consider using the [NFS Client Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/HEAD/nfs-client)
 instead.
 
 ## TL;DR;
@@ -20,7 +20,7 @@ the dynamic volumes provisioned by this chart will not be persistent!
 
 ## Introduction
 
-This chart bootstraps a [nfs-server-provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs)
+This chart bootstraps a [nfs-server-provisioner](https://github.com/kubernetes-incubator/external-storage/tree/HEAD/nfs)
 deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
 package manager.
 
@@ -54,7 +54,7 @@ their default values.
 
 | Parameter                      | Description                                                                                                     | Default                                                  |
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
-| `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments) | `{}`
+| `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/HEAD/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
 | `image.repository`             | The image repository to pull from                                                                               | `k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0`         |
 | `image.tag`                    | The image tag to pull                                                                                           | `v3.0.0`                                                 |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -13,7 +13,7 @@ image:
   pullPolicy: IfNotPresent
 
 # For a list of available arguments
-# Please see https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/deployment.md#arguments
+# Please see https://github.com/kubernetes-incubator/external-storage/blob/HEAD/nfs/docs/deployment.md#arguments
 extraArgs: {}
   # device-based-fsids: false
   # grace-period: 0


### PR DESCRIPTION
What this PR does / why we need it:
Needed for kubernetes/k8s.io#1597

Which issue(s) this PR fixes (optional, using fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged):
Needed for kubernetes/k8s.io#1597

---

As described in #55:

> "release-tools" should not be modified locally. The same change already went into csi-release-tools and will be copied from there.

Due to this, I've excluded those files from being modified in this PR but instead created https://github.com/kubernetes-csi/csi-release-tools/pull/165 for that.

And, files in `vendored` should not be updated either I assume. So, this PR updates all github links pointing to a hardcoded default branch `master` to the dynamic default branch reference `HEAD` that will reference either master or main depending on the actual default branch in the github repo.