### PR TITLE
Add clusterIP as variable

### DIFF
--- a/charts/nfs-server-provisioner/templates/service.yaml
+++ b/charts/nfs-server-provisioner/templates/service.yaml
@@ -94,6 +94,9 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
       nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   {{- with .Values.service.externalIPs }}
   externalIPs:
     {{- toYaml . | nindent 4 }}

--- a/charts/nfs-server-provisioner/templates/service.yaml
+++ b/charts/nfs-server-provisioner/templates/service.yaml
@@ -94,8 +94,8 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
       nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
-  {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
   {{- end }}
   {{- with .Values.service.externalIPs }}
   externalIPs:

--- a/charts/nfs-server-provisioner/values.yaml
+++ b/charts/nfs-server-provisioner/values.yaml
@@ -33,6 +33,7 @@ service:
   # rquotadNodePort:
   # rpcbindNodePort:
   # statdNodePort:
+  # clusterIP:
 
   externalIPs: []
 


### PR DESCRIPTION
By setting the ClusterIP it's easier to make the NFS server reachable via IP, see also this: https://github.com/kubernetes/minikube/issues/3417#issuecomment-670005434