### PR TITLE
Increase cloudbuild timeout

### DIFF
--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -16,9 +16,11 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-# Building three images in external-snapshotter takes roughly half an hour,
-# sometimes more.
-timeout: 3600s
+# Building the Dockerfile we maintain for non-amd64 architectures has been found
+# to take ~1 hour, as architecture emulation is slow. Since we may build ~4
+# non-amd64 architectures, six hours is set as a timeout to allow for some
+# margin.
+timeout: 21600s # 6h in seconds
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
We have had a timeout of ~1h in google cloud build. It seems that that is insufficient when using emulation to build a arm64 image alongside the architecture native amd64 build as done via #62.

In the future (#76), we may have 2-3 additional non-amd64 architectures to build, making us possibly need about ~4-5 hours. Due to that, I've opted to set the timeout to 6 hours.