### PR TITLE
feat(chart): allow configuration of k8s scheduling priority

### DIFF
--- a/charts/nfs-server-provisioner/Chart.yaml
+++ b/charts/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 3.0.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.3.2
+version: 1.4.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/charts/nfs-server-provisioner/README.md
+++ b/charts/nfs-server-provisioner/README.md
@@ -84,7 +84,10 @@ their default values.
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |
 | `tolerations`                  | List of node taints to tolerate                                                                                 | `[]`                                                     |
 | `affinity`                     | Map of node/pod affinities                                                                                      | `{}`                                                     |
-| `podSecurityContext`              | Security context settings for nfs-server-provisioner pod (see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)                                                        | `{}`                                                     |
+| `podSecurityContext`              | Security context settings for nfs-server-provisioner pod (see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)                                                                                                               | `{}`                                                     |
+| `priorityClass.create`         | Enable creation of a PriorityClass resource for this nfs-server-provisioner instance                            | `false`                                                  |
+| `priorityClass.name`           | Set a PriorityClass name to override the default name                                                           | `""`                                                     |
+| `priorityClass.value`          | PriorityClass value. The higher the value, the higher the scheduling priority                                   | `5`                                                      |
 
 ```console
 $ helm install nfs-server-provisioner nfs-ganesha-server-and-external-provisioner/nfs-server-provisioner \

--- a/charts/nfs-server-provisioner/templates/priorityclass.yaml
+++ b/charts/nfs-server-provisioner/templates/priorityclass.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.priorityClass.create -}}
+kind: PriorityClass
+apiVersion: scheduling.k8s.io/v1
+metadata:
+  name: {{ .Values.priorityClass.name | default (include "nfs-provisioner.fullname" .) }}
+  labels:
+    app: {{ include "nfs-provisioner.name" . }}
+    chart: {{ include "nfs-provisioner.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+value: {{ .Values.priorityClass.value }}
+globalDefault: false
+description: "This priority class should be used for nfs-provisioner pods only."
+{{- end }}

--- a/charts/nfs-server-provisioner/templates/statefulset.yaml
+++ b/charts/nfs-server-provisioner/templates/statefulset.yaml
@@ -117,6 +117,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (or .Values.priorityClass.name .Values.priorityClass.create)  }}
+      priorityClassName: {{ .Values.priorityClass.name | default (include "nfs-provisioner.fullname" .) | quote }}
+      {{- end }}
 
       {{- if not .Values.persistence.enabled }}
       volumes:

--- a/charts/nfs-server-provisioner/values.yaml
+++ b/charts/nfs-server-provisioner/values.yaml
@@ -86,6 +86,17 @@ rbac:
   ##
   serviceAccountName: default
 
+## For creating the PriorityClass automatically:
+priorityClass:
+  ## Enable creation of a PriorityClass resource for this nfs-server-provisioner instance
+  create: false
+
+  ## Set a PriorityClass name to override the default name
+  name: ""
+
+  ## PriorityClass value. The higher the value, the higher the scheduling priority
+  value: 5
+
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
allow creation or use of existing k8s priorityClass. the idea is to have the nfs-server-provisioner up and running before workloads that depend on it. see https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/