### PR TITLE
Separate base image for nfs-ganesha

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,24 +4,24 @@
 # This test is meant to verify that our Dockerfile can build successfully when
 # changed on the CPU architectures we have made it support being built on.
 #
-name: Docker build test
+name: Build nfs-ganesha base container
 
 on:
-  pull_request:
+  push:
     paths:
       - "deploy/base/Dockerfile"
-      - ".github/workflows/docker-build-test.yml"
-  workflow_dispatch:
+      - ".github/workflows/docker-build.yml"
 
 jobs:
-  build_dockerfile:
-    name: Build Dockerfile for ${{ matrix.platform }}
+  docker:
+    name: Build nfs-ganesha base container
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
       # Action reference: https://github.com/docker/setup-qemu-action
       - name: Set up QEMU (for docker buildx)
@@ -31,10 +31,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      # Action reference: https://github.com/docker/login-action
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+ 
       # Action reference: https://github.com/docker/build-push-action
       - name: Build container
         uses: docker/build-push-action@v2
         with:
           context: ./deploy/base
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-          push: false
+          push: true
+          # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:V3.5

--- a/deploy/base/Dockerfile
+++ b/deploy/base/Dockerfile
@@ -1,0 +1,104 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modified from https://github.com/rootfs/nfs-ganesha-docker by Huamin Chen
+#
+# NOTE: This Dockerfile is maintained to support being built both on amd64 and
+#       arm64 architectures.
+#
+# List of Fedora versions: https://en.wikipedia.org/wiki/Fedora_version_history#Version_history
+ARG FEDORA_VERSION=35
+
+
+
+FROM registry.fedoraproject.org/fedora:${FEDORA_VERSION} AS build
+
+# Build ganesha from source, install it to /usr/local and a use multi stage build to have a smaller image
+# Set NFS_V4_RECOV_ROOT to /export
+
+# Install dependencies on separated lines to be easier to track changes using git blame
+RUN dnf install -y \
+	bison \
+	cmake \
+	dbus-devel \
+	flex \
+	tar \
+	gcc \
+	gcc-c++ \
+	git \
+	jemalloc-devel \
+	krb5-devel \
+	libblkid-devel \
+	libnfsidmap-devel \
+	libnsl2-devel \
+	libntirpc-devel \
+	libuuid-devel \
+	ninja-build \
+	patch \
+	userspace-rcu-devel \
+	xfsprogs-devel
+
+# Clone specific version of ganesha
+# Keep version in sync with .github/workflows/docker-build.yml
+ARG GANESHA_VERSION=V3.5
+RUN git clone --branch ${GANESHA_VERSION} --recurse-submodules https://github.com/nfs-ganesha/nfs-ganesha
+WORKDIR /nfs-ganesha
+RUN mkdir -p /usr/local \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DBUILD_CONFIG=vfs_only -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_RGW=OFF \
+          -DUSE_RADOS_RECOV=OFF -DRADOS_URLS=OFF -DUSE_SYSTEM_NTIRPC=ON \
+          -G Ninja src/ \
+    && sed -i 's|@SYSSTATEDIR@/lib/nfs/ganesha|/export|' src/include/config-h.in.cmake \
+	  && ninja \
+	  && ninja install
+RUN mkdir -p /ganesha-extra \
+    && mkdir -p /ganesha-extra/etc/dbus-1/system.d \
+    && cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /ganesha-extra/etc/dbus-1/system.d/
+
+
+
+FROM registry.fedoraproject.org/fedora-minimal:${FEDORA_VERSION} AS run
+
+# Install dependencies on separated lines to be easier to track changes using git blame
+RUN microdnf install -y \
+	dbus-x11 \
+	hostname \
+	jemalloc \
+	libblkid \
+	libnfsidmap \
+	libntirpc \
+	libuuid \
+	nfs-utils \
+	rpcbind \
+	userspace-rcu \
+	xfsprogs \
+    && microdnf clean all
+
+RUN mkdir -p /var/run/dbus \
+    && mkdir -p /export
+
+# add libs from /usr/local/lib64
+RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local_libs.conf
+
+# do not ask systemd for user IDs or groups (slows down dbus-daemon start)
+RUN sed -i s/systemd// /etc/nsswitch.conf
+
+COPY --from=build /usr/local /usr/local/
+COPY --from=build /ganesha-extra /
+
+# run ldconfig after libs have been copied
+RUN ldconfig
+
+# expose mountd 20048/tcp and nfsd 2049/tcp and rpcbind 111/tcp 111/udp
+EXPOSE 2049/tcp 20048/tcp 111/tcp 111/udp


### PR DESCRIPTION
Github Actions is much faster at cross-compiling nfs-ganesha than Prow, and there really no benefit to rebuilding nfs-ganesha every time nfs-provisioner changes.  Therefore, this separates the nfs-ganesha build into a separate base image to be updated only as new versions of it or its Fedora base become available.

Once this is merged and built, the next step will be a second PR to deploy/docker/Dockerfile to simply inherit the nfs-ganesha build and copy in the nfs-provisioner library.  This does mean that future updates to nfs-ganesha in nfs-provisioner will be a two-step process, but this will take the cross-compiling burden off of prow.
