### PR TITLE
Use "servicename.namespace" as address for the NFS server

### DIFF
--- a/cmd/nfs-provisioner/main.go
+++ b/cmd/nfs-provisioner/main.go
@@ -41,7 +41,7 @@ var (
 	useGanesha     = flag.Bool("use-ganesha", true, "If the provisioner will create volumes using NFS Ganesha (D-Bus method calls) as opposed to using the kernel NFS server ('exportfs'). If run-server is true, this must be true. Default true.")
 	gracePeriod    = flag.Uint("grace-period", 90, "NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.")
 	enableXfsQuota = flag.Bool("enable-xfs-quota", false, "If the provisioner will set xfs quotas for each volume it provisions. Requires that the directory it creates volumes in ('/export') is xfs mounted with option prjquota/pquota, and that it has the privilege to run xfs_quota. Default false.")
-	serverHostname = flag.String("server-hostname", "", "The hostname for the NFS server to export from. Only applicable when running out-of-cluster i.e. it can only be set if either master or kubeconfig are set. If unset, the first IP output by `hostname -i` is used.")
+	serverHostname = flag.String("server-hostname", "", "The hostname for the NFS server to export from. If unset and running out-of-cluster, the first IP output by `hostname -i` is used.")
 	exportSubnet   = flag.String("export-subnet", "*", "Subnet for NFS export to allow mount only from")
 	maxExports     = flag.Int("max-exports", -1, "The maximum number of volumes to be exported by this provisioner. New claims will be ignored once this limit has been reached. A negative value is interpreted as 'unlimited'. Default -1.")
 	fsidDevice     = flag.Bool("device-based-fsids", true, "If file system handles created by NFS Ganesha should be based on major/minor device IDs of the backing storage volume ('/export'). Default true.")
@@ -80,10 +80,6 @@ func main() {
 
 	// Create the client according to whether we are running in or out-of-cluster
 	outOfCluster := *master != "" || *kubeconfig != ""
-
-	if !outOfCluster && *serverHostname != "" {
-		glog.Fatalf("Invalid flags specified: if server-hostname is set, either master or kube-config must also be set.")
-	}
 
 	if *runServer {
 		glog.Infof("Setting up NFS server!")

--- a/pkg/volume/provision.go
+++ b/pkg/volume/provision.go
@@ -485,8 +485,11 @@ func (p *nfsProvisioner) getServer() (string, error) {
 	// inside Kubernetes, such DNS names do not exist on normally configured clusters.
 	if nodes_support_cluster_local {
 		// we go for the namespace name and service name, and rely on the node to find the IP address
+        // (it is debatable whether we should use the FWDN "name.ns.svc.cluster.local" or rely on the 
+        // node to have a search path that contain "cluster.local" or "svc.cluster.local" (which is 
+        // often the case). In our case we rely on the search path to contain 'cluster.local')
 		glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
-		return serviceName + "." + namespace + ".svc.cluster.local", nil
+		return serviceName + "." + namespace + ".svc", nil
 	} else {
 		// the nodes do not support internal DNS names, so we have to hand out an IP address anyway
 		// (users better put hardcoded IPs in their service definition to survive service-recreation)

--- a/pkg/volume/provision.go
+++ b/pkg/volume/provision.go
@@ -371,7 +371,9 @@ func (p *nfsProvisioner) getServer() (string, error) {
 	}
 
     // we want the persistentvolume to connect to the "servicename.namespace" hostname, so that
-    // it will survive any restarts of the pod or node on which the nfs server happens to be running
+    // it will survive any restarts of the service, pod or node on which the nfs server happens 
+    // to be running (in previous versions we returned the service IP here, which was a bit less 
+    // stable in case of changes or to the service)
 	namespace := os.Getenv(p.namespaceEnv)
 	serviceName := os.Getenv(p.serviceEnv)
 

--- a/pkg/volume/provision.go
+++ b/pkg/volume/provision.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -370,56 +370,56 @@ func (p *nfsProvisioner) getServer() (string, error) {
 		return "", fmt.Errorf("hostname -i had bad output %s, no address to use", string(out))
 	}
 
-    // we want the persistentvolume to connect to the "servicename.namespace" hostname, so that
-    // it will survive any restarts of the service, pod or node on which the nfs server happens 
-    // to be running (in previous versions we returned the service IP here, which was a bit less 
-    // stable in case of changes or to the service)
+	// we want the persistentvolume to connect to the "servicename.namespace" hostname, so that
+	// it will survive any restarts of the service, pod or node on which the nfs server happens 
+	// to be running (in previous versions we returned the service IP here, which was a bit less 
+	// stable in case of changes or to the service)
 	namespace := os.Getenv(p.namespaceEnv)
 	serviceName := os.Getenv(p.serviceEnv)
 
-    // we already fetch the podIp because we need it a number of times
-    podIP := os.Getenv(p.podIPEnv)
+	// we already fetch the podIp because we need it a number of times
+	podIP := os.Getenv(p.podIPEnv)
 
-    // In the unlikely case that we do not have a namespace or servicename, we will try some alternatives
-    // so that we have _at least_ a volume that we can offer to the caller (although not a very stable one)
-    // TODO Is it clever to use these alternatives in the first place instead of just crashing? Handing
-    //      out such an unstable server name is a bit like waiting for a future disaster that will hit somebody
-    //      when nobody is around to solve it.   
-    if (namespace == "" || serviceName == "") {
+	// In the unlikely case that we do not have a namespace or servicename, we will try some alternatives
+	// so that we have _at least_ a volume that we can offer to the caller (although not a very stable one)
+	// TODO Is it clever to use these alternatives in the first place instead of just crashing? Handing
+	//      out such an unstable server name is a bit like waiting for a future disaster that will hit somebody
+	//      when nobody is around to solve it.   
+	if (namespace == "" || serviceName == "") {
 
-        // report a warning
+		// report a warning
 		glog.Infof("using potentially unstable server address (because namespace env %s and/or service env %s are not set)", p.namespaceEnv, p.serviceEnv)
-        
-        // alternative 1: we use the name of the node, naively hoping that the node never dies
-        nodeName := os.Getenv(p.nodeEnv)
-        if nodeName != "" {
-            glog.Infof("using node name %s=%s as dangerous NFS server IP", p.nodeEnv, nodeName)
-            return nodeName, nil
-        }
-        
-        // alternative 2: we use the ip address of the pod, naively hoping that pods never crash or restart
-        if podIP != "" {
-            glog.Infof("using pod IP %s=%s as dangerous NFS server IP", p.podIPEnv, podIP)
-            return podIP, nil;
-        }
-        
-        // we're out of alternatives, report an error
-        return "", fmt.Errorf("no alternatives found for the NFS server address (node env %s and pod env %s not set)", p.nodeEnv, p.podIPEnv)
-    }
+		
+		// alternative 1: we use the name of the node, naively hoping that the node never dies
+		nodeName := os.Getenv(p.nodeEnv)
+		if nodeName != "" {
+			glog.Infof("using node name %s=%s as dangerous NFS server IP", p.nodeEnv, nodeName)
+			return nodeName, nil
+		}
+		
+		// alternative 2: we use the ip address of the pod, naively hoping that pods never crash or restart
+		if podIP != "" {
+			glog.Infof("using pod IP %s=%s as dangerous NFS server IP", p.podIPEnv, podIP)
+			return podIP, nil;
+		}
+		
+		// we're out of alternatives, report an error
+		return "", fmt.Errorf("no alternatives found for the NFS server address (node env %s and pod env %s not set)", p.nodeEnv, p.podIPEnv)
+	}
 
-    // check if the service does actually exist
+	// check if the service does actually exist
 	service, err := p.client.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error getting service %s=%s in namespace %s=%s", p.serviceEnv, serviceName, p.namespaceEnv, namespace)
 	}
-    
+	
 	// We are almost ready to use the "servicename.namespace" name, but we first do some validation of the 
-    // service before provisioning a potential useless volume
-    // TODO Does this validation actually belong here? One could argue that it is not our (single) responsibility 
-    //      to check the service for correctness, and that the whole idea of having services is that you can rely 
-    //      on them, without having to worry about their implementation or configuration. By having this check 
-    //      here, the provisioner is now suddenly also supposed to be a NFS specialist, breaking the single
-    //      responsibility principle. Future (valid) changes to the NFS protocol or service now break the provisioner!
+	// service before provisioning a potential useless volume
+	// TODO Does this validation actually belong here? One could argue that it is not our (single) responsibility 
+	//      to check the service for correctness, and that the whole idea of having services is that you can rely 
+	//      on them, without having to worry about their implementation or configuration. By having this check 
+	//      here, the provisioner is now suddenly also supposed to be a NFS specialist, breaking the single
+	//      responsibility principle. Future (valid) changes to the NFS protocol or service now break the provisioner!
 	valid := false
 	type endpointPort struct {
 		port     int32
@@ -472,8 +472,8 @@ func (p *nfsProvisioner) getServer() (string, error) {
 	glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
 	return serviceName + "." + namespace, nil
 
-    // we just go for the namespace name and service name
-    return serviceName + "." + namespace, nil
+	// we just go for the namespace name and service name
+	return serviceName + "." + namespace, nil
 }
 
 func (p *nfsProvisioner) checkExportLimit() bool {

--- a/pkg/volume/provision.go
+++ b/pkg/volume/provision.go
@@ -354,15 +354,15 @@ func (p *nfsProvisioner) validateOptions(options controller.ProvisionOptions) (s
 
 // getServer gets the server IP to put in a provisioned PV's spec.
 func (p *nfsProvisioner) getServer() (string, error) {
-    
-    // if the user supplied a hardcoded server name as command line argument, we always use that,
-    // this is useful when the provisioner is running out of the cluster AND when the user knows
-    // better which DNS to use (for example in case they run a non-standard DNS service on the nodes
-    // that allows them to find service IP's based on DNS names)
-    if (p.serverHostname != "") {
-        return p.serverHostname, nil
-    }
-    
+	
+	// if the user supplied a hardcoded server name as command line argument, we always use that,
+	// this is useful when the provisioner is running out of the cluster AND when the user knows
+	// better which DNS to use (for example in case they run a non-standard DNS service on the nodes
+	// that allows them to find service IP's based on DNS names)
+	if (p.serverHostname != "") {
+		return p.serverHostname, nil
+	}
+	
 	if p.outOfCluster {
 		// TODO make this better
 		out, err := exec.Command("hostname", "-i").Output()
@@ -420,7 +420,7 @@ func (p *nfsProvisioner) getServer() (string, error) {
 	}
 	
 	// We are almost ready to use the "clientIP" or "servicename.namespace" name, but we first do some validation 
-    // of the service before provisioning a potential useless volume
+	// of the service before provisioning a potential useless volume
 	// TODO Does this validation actually belong here? One could argue that it is not our (single) responsibility 
 	//      to check the service for correctness, and that the whole idea of having services is that you can rely 
 	//      on them, without having to worry about their implementation or configuration. By having this check 
@@ -475,24 +475,24 @@ func (p *nfsProvisioner) getServer() (string, error) {
 		return "", fmt.Errorf("service %s=%s is valid but it doesn't have a cluster IP", p.serviceEnv, serviceName)
 	}
 
-    // do the nodes support "cluster.local" internal DNS names?
-    // TODO maybe we can auto-detect this, or make this user-configurable?
-    nodes_support_cluster_local := false
+	// do the nodes support "cluster.local" internal DNS names?
+	// TODO maybe we can auto-detect this, or make this user-configurable?
+	nodes_support_cluster_local := false
 
-    // in a perfect world we would like to hand out a "service.namespace.svc.cluster.local" address,
-    // because then the NFS mount point will also work in case of a disaster (service is recreated
-    // with a new IP). However, because the "mount -t nfs" command is given on the nodes and not 
-    // inside Kubernetes, such DNS names do not exist on normally configured clusters.
-    if nodes_support_cluster_local {
-	    // we go for the namespace name and service name, and rely on the node to find the IP address
-	    glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
-	    return serviceName + "." + namespace + ".svc.cluster.local", nil
-    } else {
-        // the nodes do not support internal DNS names, so we have to hand out an IP address anyway
-        // (users better put hardcoded IPs in their service definition to survive service-recreation)
-	    glog.Infof("using service %s=%s clusterIP %s as NFS server IP", p.serviceEnv, serviceName, service.Spec.ClusterIP)
-        return service.Spec.ClusterIP, nil
-    }
+	// in a perfect world we would like to hand out a "service.namespace.svc.cluster.local" address,
+	// because then the NFS mount point will also work in case of a disaster (service is recreated
+	// with a new IP). However, because the "mount -t nfs" command is given on the nodes and not 
+	// inside Kubernetes, such DNS names do not exist on normally configured clusters.
+	if nodes_support_cluster_local {
+		// we go for the namespace name and service name, and rely on the node to find the IP address
+		glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
+		return serviceName + "." + namespace + ".svc.cluster.local", nil
+	} else {
+		// the nodes do not support internal DNS names, so we have to hand out an IP address anyway
+		// (users better put hardcoded IPs in their service definition to survive service-recreation)
+		glog.Infof("using service %s=%s clusterIP %s as NFS server IP", p.serviceEnv, serviceName, service.Spec.ClusterIP)
+		return service.Spec.ClusterIP, nil
+	}
 }
 
 func (p *nfsProvisioner) checkExportLimit() bool {

--- a/pkg/volume/provision.go
+++ b/pkg/volume/provision.go
@@ -471,7 +471,7 @@ func (p *nfsProvisioner) getServer() (string, error) {
 
 	// we just go for the namespace name and service name
 	glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
-	return serviceName + "." + namespace, nil
+	return serviceName + "." + namespace + ".svc.cluster.local", nil
 }
 
 func (p *nfsProvisioner) checkExportLimit() bool {

--- a/pkg/volume/provision.go
+++ b/pkg/volume/provision.go
@@ -469,10 +469,8 @@ func (p *nfsProvisioner) getServer() (string, error) {
 		return "", fmt.Errorf("service %s=%s is valid but it doesn't have a cluster IP", p.serviceEnv, serviceName)
 	}
 
-	glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
-	return serviceName + "." + namespace, nil
-
 	// we just go for the namespace name and service name
+	glog.Infof("using service %s=%s hostname %s.%s as NFS server IP", p.serviceEnv, serviceName, serviceName, namespace)
 	return serviceName + "." + namespace, nil
 }
 


### PR DESCRIPTION
Hello,

Maybe I do not understand the reason for using the service IP address in the PersistentVolume, but it does not seem to be a very reliable setup. This was also mentioned in issue #79. These IP addresses happen to change every now and then, leaving the PersistentVolume in a useless state. In this pull request I modified the code a bit to use "servicename.namespace" as the server address. I have the feeling that that makes more sense and is better for reliable use in production environments.

I also added some comments next to the lines that sursprised me a bit while working on this. For example why the provisioner hands out pod ips or node ips as server addresses, because those addresses are not so reliable either. And I wondered why the provisioner picks up the responsibility for checking the correctness of the service. Those are however just comments and I did not modify the code any further.

I am new to Kubernetes and this is the first time that I touched any Go code. So my apologies for anything stupid that I did. In that case I am happy to receive feedback to improve my work.

Thanks,

Emiel
