### PR TITLE
Fix Execution on Fedora 36 and Kubernetes v1.24.3

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,4 +47,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
-          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:V3.5
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:V4.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.5.0
+- Rebase on Fedora 36
+- Upgrade Ganesha to 4.0.8
+- Switch to new repo for dbus
+
 # v1.0.8
 - Add mountOptions StorageClass parameter (#84) (see [Usage](./docs/usage.md) for complete SC parameter info)
 - Replace root-squash argument with a rootSquash SC parameter (#86) (see [Usage](./docs/usage.md) for complete SC parameter info)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.5.0
+# v1.6.0
 - Rebase on Fedora 36
 - Upgrade Ganesha to 4.0.8
 - Switch to new repo for dbus

--- a/charts/nfs-server-provisioner/Chart.yaml
+++ b/charts/nfs-server-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 3.0.0
+appVersion: 4.0.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.4.0
+version: 1.5.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/charts/nfs-server-provisioner/Chart.yaml
+++ b/charts/nfs-server-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 4.0.0
+appVersion: 4.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.5.0
+version: 1.6.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/charts/nfs-server-provisioner/README.md
+++ b/charts/nfs-server-provisioner/README.md
@@ -57,8 +57,8 @@ their default values.
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
 | `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/HEAD/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
-| `image.repository`             | The image repository to pull from                                                                               | `k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0`         |
-| `image.tag`                    | The image tag to pull                                                                                           | `v3.0.0`                                                 |
+| `image.repository`             | The image repository to pull from                                                                               | `k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0`         |
+| `image.tag`                    | The image tag to pull                                                                                           | `v4.0.0`                                                 |
 | `image.digest`                 | The image digest to pull, this option has precedence over `image.tag`                                           | `nil`                                                    |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |

--- a/charts/nfs-server-provisioner/README.md
+++ b/charts/nfs-server-provisioner/README.md
@@ -57,8 +57,8 @@ their default values.
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
 | `extraArgs` | [Additional command line arguments](https://github.com/kubernetes-incubator/external-storage/blob/HEAD/nfs/docs/deployment.md#arguments) | `{}`
 | `imagePullSecrets`             | Specify image pull secrets                                                                                      | `nil` (does not add image pull secrets to deployed pods) |
-| `image.repository`             | The image repository to pull from                                                                               | `k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0`         |
-| `image.tag`                    | The image tag to pull                                                                                           | `v4.0.0`                                                 |
+| `image.repository`             | The image repository to pull from                                                                               | `k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8`         |
+| `image.tag`                    | The image tag to pull                                                                                           | `v4.0.8`                                                 |
 | `image.digest`                 | The image digest to pull, this option has precedence over `image.tag`                                           | `nil`                                                    |
 | `image.pullPolicy`             | Image pull policy                                                                                               | `IfNotPresent`                                           |
 | `service.type`                 | service type                                                                                                    | `ClusterIP`                                              |

--- a/charts/nfs-server-provisioner/values.yaml
+++ b/charts/nfs-server-provisioner/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: k8s.gcr.io/sig-storage/nfs-provisioner
-  tag: v3.0.0
+  tag: v4.0.0
   # digest:
   pullPolicy: IfNotPresent
 

--- a/charts/nfs-server-provisioner/values.yaml
+++ b/charts/nfs-server-provisioner/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: k8s.gcr.io/sig-storage/nfs-provisioner
-  tag: v4.0.0
+  tag: v4.0.8
   # digest:
   pullPolicy: IfNotPresent
 

--- a/deploy/base/Dockerfile
+++ b/deploy/base/Dockerfile
@@ -18,7 +18,7 @@
 #       arm64 architectures.
 #
 # List of Fedora versions: https://en.wikipedia.org/wiki/Fedora_version_history#Version_history
-ARG FEDORA_VERSION=35
+ARG FEDORA_VERSION=36
 
 
 
@@ -51,7 +51,7 @@ RUN dnf install -y \
 
 # Clone specific version of ganesha
 # Keep version in sync with .github/workflows/docker-build.yml
-ARG GANESHA_VERSION=V3.5
+ARG GANESHA_VERSION=V4.0.8
 RUN git clone --branch ${GANESHA_VERSION} --recurse-submodules https://github.com/nfs-ganesha/nfs-ganesha
 WORKDIR /nfs-ganesha
 RUN mkdir -p /usr/local \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Update only after new version of deploy/base/Dockerfile change has built
-ARG GANESHA_VERSION=V3.5
+ARG GANESHA_VERSION=V4.0.8
 
 
 FROM ghcr.io/kubernetes-sigs/nfs-ganesha:${GANESHA_VERSION}

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccount: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
+          image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
           ports:
             - name: nfs
               containerPort: 2049

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccount: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
+          image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8
           ports:
             - name: nfs
               containerPort: 2049

--- a/deploy/kubernetes/pod.yaml
+++ b/deploy/kubernetes/pod.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccount: nfs-provisioner
   containers:
     - name: nfs-provisioner
-      image: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
+      image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
       ports:
         - name: nfs
           containerPort: 2049

--- a/deploy/kubernetes/pod.yaml
+++ b/deploy/kubernetes/pod.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccount: nfs-provisioner
   containers:
     - name: nfs-provisioner
-      image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
+      image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8
       ports:
         - name: nfs
           containerPort: 2049

--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: nfs-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
+          image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
           ports:
             - name: nfs
               containerPort: 2049

--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: nfs-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
+          image: k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8
           ports:
             - name: nfs
               containerPort: 2049

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ $ make container
 If you are running in Kubernetes, it will pull the image from GCR for you. Or you can do it yourself.
 
 ```
-$ docker pull k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0
+$ docker pull k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
 ```
 
 ## Deploying the provisioner
@@ -82,7 +82,7 @@ You may want to specify the hostname the NFS server exports from, i.e. the serve
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
 -v $HOME/.kube:/.kube:Z \
-k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config
 ```
@@ -90,7 +90,7 @@ or
 ```
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
-k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0 \
 -provisioner=example.com/nfs \
 -master=http://172.17.0.1:8080
 ```
@@ -105,7 +105,7 @@ With the two above options, the run command will look something like this.
 $ docker run --privileged \
 -v $HOME/.kube:/.kube:Z \
 -v /xfs:/export:Z \
-k8s.gcr.io/sig-storage/nfs-provisioner:v3.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config \
 -enable-xfs-quota=true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ $ make container
 If you are running in Kubernetes, it will pull the image from GCR for you. Or you can do it yourself.
 
 ```
-$ docker pull k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0
+$ docker pull k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8
 ```
 
 ## Deploying the provisioner
@@ -82,7 +82,7 @@ You may want to specify the hostname the NFS server exports from, i.e. the serve
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
 -v $HOME/.kube:/.kube:Z \
-k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config
 ```
@@ -90,7 +90,7 @@ or
 ```
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
-k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8 \
 -provisioner=example.com/nfs \
 -master=http://172.17.0.1:8080
 ```
@@ -105,7 +105,7 @@ With the two above options, the run command will look something like this.
 $ docker run --privileged \
 -v $HOME/.kube:/.kube:Z \
 -v /xfs:/export:Z \
-k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.0 \
+k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config \
 -enable-xfs-quota=true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/guelfey/go.dbus v0.0.0-20131113121618-f6a3a2366cc3
+	github.com/godbus/dbus v4.1.0+incompatible
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/kubernetes-sigs/sig-storage-lib-external-provisioner v4.0.0+incompatible
 	github.com/miekg/dns v1.1.15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,12 @@ module github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
 go 1.12
 
 require (
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/godbus/dbus v4.1.0+incompatible
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/kubernetes-sigs/sig-storage-lib-external-provisioner v4.0.0+incompatible
 	github.com/miekg/dns v1.1.25 // indirect
 	github.com/prometheus/client_golang v1.1.0 // indirect
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	k8s.io/api v0.0.0-20190814101207-0772a1bdf941

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
+github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
@@ -61,8 +63,6 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/guelfey/go.dbus v0.0.0-20131113121618-f6a3a2366cc3 h1:fngCxKbvZdctIsWj2hYijhAt4iK0JXSSA78B36xP0yI=
-github.com/guelfey/go.dbus v0.0.0-20131113121618-f6a3a2366cc3/go.mod h1:0CNX5Cvi77WEH8llpfZ/ieuqyceb1cnO5//b5zzsnF8=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/kubernetes-sigs/sig-storage-lib-external-provisioner v4.0.0+incompati
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/miekg/dns v1.1.15 h1:CSSIDtllwGLMoA6zjdKnaE6Tx6eVUxQ29LUgGetiDCI=
-github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.25 h1:dFwPR6SfLtrSwgDcIq2bcU/gVutB4sNApq2HBdqcakg=
+github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -146,6 +146,8 @@ golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
+golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -154,8 +156,11 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190206173232-65e2d4e15006/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -163,6 +168,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -174,6 +180,9 @@ golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 h1:4y9KwBHBgBNwDbtu44R5o1fdOCQUEXhbk/P4A9WmJq0=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -185,6 +194,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,24 +39,22 @@ var defaultGaneshaConfigContents = []byte(`
 #
 ###################################################
 
-EXPORT
-{
+EXPORT {
+
 	# Export Id (mandatory, each EXPORT must have a unique Export_Id)
 	Export_Id = 0;
-
 	# Exported path (mandatory)
-	Path = /nonexistent;
-
+	Path = /;
 	# Pseudo Path (required for NFS v4)
-	Pseudo = /nonexistent;
+	Pseudo = /;
+	Protocols = 4;
+	Access_Type = MDONLY_RO;
+	Filesystem_Id = 152.152;
 
-	# Required for access (default is None)
-	# Could use CLIENT blocks instead
-	Access_Type = RW;
-
-	# Exporting FSAL
 	FSAL {
-		Name = VFS;
+
+		Name = PSEUDO;
+
 	}
 }
 

--- a/pkg/volume/export.go
+++ b/pkg/volume/export.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/guelfey/go.dbus"
+	"github.com/godbus/dbus"
 	"k8s.io/api/core/v1"
 )
 


### PR DESCRIPTION
With Fedora CoreOS 36 and Kubernetes v1.24.3 the container hangs in a CrashLoopBackoff and has to be OOM-killed by the kernel.

With a rebase on F36 and the latest ganesha, the problem is gone. 