### PR TITLE
Updating the version of github.com/miekg/dns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/guelfey/go.dbus v0.0.0-20131113121618-f6a3a2366cc3
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/kubernetes-sigs/sig-storage-lib-external-provisioner v4.0.0+incompatible
-	github.com/miekg/dns v1.1.15 // indirect
+	github.com/miekg/dns v1.1.25 // indirect
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect


### PR DESCRIPTION
Updating the version of github.com/miekg/dns to fix security vulnerability.
This will fix: Insecure Randomness. It improperly generates random numbers because math/rand is used. The TXID becomes predictable, leading to response forgeries.