### PR TITLE
Authorize RBAC to use `scc/privileged`

### DIFF
--- a/charts/nfs-server-provisioner/templates/clusterrole.yaml
+++ b/charts/nfs-server-provisioner/templates/clusterrole.yaml
@@ -31,4 +31,8 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["privileged"]
+    verbs: ["use"]
 {{- end }}


### PR DESCRIPTION
Otherwise OpenShift refuses to create the NFS server pod for security reasons.

Not tested directly, but it works to use the published chart after

```bash
kubectl create clusterrolebinding scc-nfs --clusterrole system:openshift:scc:privileged --serviceaccount my-namespace:the-rbac-sa-name
```

where the standard role is predefined

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: system:openshift:scc:privileged
  ownerReferences:
  - apiVersion: config.openshift.io/v1
    kind: ClusterVersion
    name: version
    uid: …
rules:
- apiGroups:
  - security.openshift.io
  resourceNames:
  - privileged
  resources:
  - securitycontextconstraints
  verbs:
  - use
```
