### PR TITLE
Use HELM chart to configure container security contex

### DIFF
--- a/charts/nfs-server-provisioner/Chart.yaml
+++ b/charts/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 4.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.6.0
+version: 1.7.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/charts/nfs-server-provisioner/templates/statefulset.yaml
+++ b/charts/nfs-server-provisioner/templates/statefulset.yaml
@@ -73,11 +73,10 @@ spec:
             - name: statd-udp
               containerPort: 662
               protocol: UDP
+          {{- with .Values.securityContext }}
           securityContext:
-            capabilities:
-              add:
-                - DAC_READ_SEARCH
-                - SYS_RESOURCE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - "-provisioner={{ include "nfs-provisioner.provisionerName" . }}"
             {{- range $key, $value := .Values.extraArgs }}

--- a/charts/nfs-server-provisioner/values.yaml
+++ b/charts/nfs-server-provisioner/values.yaml
@@ -39,7 +39,7 @@ service:
 
 persistence:
   enabled: false
-  
+
   ## Existing Persistent Volume Claim
   ## This should be used with persistence.enabled=true
   ## If defined, an existing volume claim will be used, instead
@@ -95,6 +95,12 @@ rbac:
   ## Ignored if rbac.create is true
   ##
   serviceAccountName: default
+
+securityContext:
+  capabilities:
+    add:
+      - DAC_READ_SEARCH
+      - SYS_RESOURCE
 
 ## For creating the PriorityClass automatically:
 priorityClass:


### PR DESCRIPTION
This PR enables operators to customize the capabilities of the nfs-server-provisioner container.

Currently the nfs-server-provisioner fails to export its volumes properly after a restart with the following errors:
```
24/01/2023 13:21:04 : epoch 63cfdb40 : nfs-server-provisioner-dev-0 : nfs-ganesha-19[main] vfs_lookup_path :FSAL :CRIT :Could not get handle for path /export/pvc-f8b7f7fa-5c57-45e8-a5c0-7b4dd656fefb, error Operation not permitted
24/01/2023 13:21:04 : epoch 63cfdb40 : nfs-server-provisioner-dev-0 : nfs-ganesha-19[main] init_export_root :EXPORT :CRIT :Lookup failed on path, ExportId=1 Path=/export/pvc-f8b7f7fa-5c57-45e8-a5c0-7b4dd656fefb FSAL_ERROR=(Forbidden action,1)
```

This PR would allow operators, who are willing to compromise a bit on security, to enable more capabilities or run the container as privileged.
As a dirty workaround, someone could add the capability "SYS_ADMIN" for example.