### PR TITLE
set GANESHA_VERSION from Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set GANESHA_VERSION
+      - name: Set ganesha version
         run: perl -ne 'print "$1\n" if /^ARG (GANESHA_VERSION=.+)$/' deploy/base/Dockerfile >> $GITHUB_ENV
 
       # Action reference: https://github.com/docker/build-push-action

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
-          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ GANESHA_VERSION }}
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ env.GANESHA_VERSION }}
 
       - name: Setup go
         uses: actions/setup-go@v3
@@ -70,4 +70,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
-          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ GANESHA_VERSION }}
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ env.GANESHA_VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,7 +50,6 @@ jobs:
           context: ./deploy/base
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
-          # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
           tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ env.GANESHA_VERSION }}
 
       - name: Setup go
@@ -69,5 +68,4 @@ jobs:
           file: ./deploy/docker/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
-          # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
           tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ env.GANESHA_VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,17 +33,36 @@ jobs:
 
       # Action reference: https://github.com/docker/login-action
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
- 
+
+      # Action reference: https://github.com/docker/build-push-action
+      - name: Build base container
+        uses: docker/build-push-action@v2
+        with:
+          context: ./deploy/base
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:V4.0.8
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20.1'
+
+      - name: Build nfs-provisioner
+        run: make build
+
       # Action reference: https://github.com/docker/build-push-action
       - name: Build container
         uses: docker/build-push-action@v2
         with:
-          context: ./deploy/base
+          context: bin
+          file: ./deploy/docker/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ on:
   push:
     paths:
       - "deploy/base/Dockerfile"
+      - "deploy/docker/Dockerfile"
       - ".github/workflows/docker-build.yml"
 
 jobs:
@@ -39,6 +40,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set GANESHA_VERSION
+        run: perl -ne 'print "$1\n" if /^ARG (GANESHA_VERSION=.+)$/' deploy/base/Dockerfile >> $GITHUB_ENV
+
       # Action reference: https://github.com/docker/build-push-action
       - name: Build base container
         uses: docker/build-push-action@v2
@@ -47,7 +51,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
-          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:V4.0.8
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ GANESHA_VERSION }}
 
       - name: Setup go
         uses: actions/setup-go@v3
@@ -66,4 +70,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           # keep tag in sync with deploy/base/Dockerfile:GANESHA_VERSION
-          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:V4.0.8
+          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ GANESHA_VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,13 +4,12 @@
 # This test is meant to verify that our Dockerfile can build successfully when
 # changed on the CPU architectures we have made it support being built on.
 #
-name: Build nfs-ganesha container
+name: Build nfs-ganesha base container
 
 on:
   push:
     paths:
       - "deploy/base/Dockerfile"
-      - "deploy/docker/Dockerfile"
       - ".github/workflows/docker-build.yml"
 
 jobs:
@@ -44,28 +43,10 @@ jobs:
         run: perl -ne 'print "$1\n" if /^ARG (GANESHA_VERSION=.+)$/' deploy/base/Dockerfile >> $GITHUB_ENV
 
       # Action reference: https://github.com/docker/build-push-action
-      - name: Build base container
-        uses: docker/build-push-action@v2
-        with:
-          context: ./deploy/base
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ env.GANESHA_VERSION }}
-
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.20.1'
-
-      - name: Build nfs-provisioner
-        run: make build
-
-      # Action reference: https://github.com/docker/build-push-action
       - name: Build container
         uses: docker/build-push-action@v2
         with:
-          context: bin
-          file: ./deploy/docker/Dockerfile
+          context: ./deploy/base
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/nfs-ganesha:${{ env.GANESHA_VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,7 @@
 # This test is meant to verify that our Dockerfile can build successfully when
 # changed on the CPU architectures we have made it support being built on.
 #
-name: Build nfs-ganesha base container
+name: Build nfs-ganesha container
 
 on:
   push:


### PR DESCRIPTION
Proposed fix for #115 

This will publish image on ghcr.io instead of registry.k8s.io.

I was able to build and publish image here https://github.com/revant/nfs-ganesha-server-and-external-provisioner/actions/runs/4340538329/jobs/7579174476 and it was published successfully on ghcr.

At this moment the registry credentials are configured for ghcr.

To use registry.k8s.io I can change the `tags` for the docker build steps, It will not work without authentication.

Additional references to image in the repo will also need to change.

Are there any ENV vars that I can already use for registry.k8s.io? 
