### PR TITLE
allow specification of pod annotations through helm chart

### DIFF
--- a/charts/nfs-server-provisioner/templates/statefulset.yaml
+++ b/charts/nfs-server-provisioner/templates/statefulset.yaml
@@ -22,6 +22,10 @@ spec:
         chart: {{ include "nfs-provisioner.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       # NOTE: This is 10 seconds longer than the default nfs-provisioner --grace-period value of 90sec
       terminationGracePeriodSeconds: 100

--- a/charts/nfs-server-provisioner/values.yaml
+++ b/charts/nfs-server-provisioner/values.yaml
@@ -121,6 +121,8 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+podAnnotations: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Hi!

I have a need to annotate the NFS pod for backup purposes, but the helm chart does not currently support it. I've made a quick PR to support it in case other people might find it useful as well.