### PR TITLE
Fixed: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -49,7 +49,7 @@ cp -r $TEST_DIR/testing-manifests/* ./test/e2e/testing-manifests
 
 # Download kubectl to _output directory
 if [ ! -e "$HOME/bin/kubectl" ]; then
-  curl -o $HOME/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  curl -o $HOME/bin/kubectl -LO https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
   chmod +x $HOME/bin/kubectl
 fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396