### PR TITLE
Allow the provisioner to be configured to disable ID Mapping

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -161,3 +161,4 @@ Now that you have finished deploying the provisioner, go to [Usage](usage.md) fo
 * `failed-retry-threshold` - If the number of retries on provisioning failure need to be limited to a set number of attempts. Default 10
 * `server-hostname` - The hostname for the NFS server to export from. Only applicable when running out-of-cluster i.e. it can only be set if either master or kubeconfig are set. If unset, the first IP output by `hostname -i` is used.
 * `device-based-fsids` - If file system handles created by NFS Ganesha should be based on major/minor device IDs of the backing storage volume ('/export'). When running a cloud based kubernetes service (like Googles GKE service) set this to `false` as it might affect client connections on restarts of the nfs provisioner pod. Default true.
+* `disable-id-mapping` - Configure NFS Ganesha to disable ID mapping for NFSv4 mounts. Can only be set if both run-server and use-ganesha are true. Default false.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,12 +70,13 @@ NFS_Core_Param
 NFSV4
 {
 	Grace_Period = 90;
+	Only_Numeric_Owners = false;
 }
 `)
 
 // Setup sets up various prerequisites and settings for the server. If an error
 // is encountered at any point it returns it instantly
-func Setup(ganeshaConfig string, gracePeriod uint, fsidDevice bool) error {
+func Setup(ganeshaConfig string, gracePeriod uint, fsidDevice, disableIDMapping bool) error {
 	// Start rpcbind if it is not started yet
 	cmd := exec.Command("/usr/sbin/rpcinfo", "127.0.0.1")
 	if err := cmd.Run(); err != nil {
@@ -109,6 +110,10 @@ func Setup(ganeshaConfig string, gracePeriod uint, fsidDevice bool) error {
 		}
 	}
 	err = setGracePeriod(ganeshaConfig, gracePeriod)
+	if err != nil {
+		return fmt.Errorf("error setting grace period to ganesha config: %v", err)
+	}
+	err = setNumericOwners(ganeshaConfig, disableIDMapping)
 	if err != nil {
 		return fmt.Errorf("error setting grace period to ganesha config: %v", err)
 	}
@@ -265,6 +270,46 @@ func setGracePeriod(ganeshaConfig string, gracePeriod uint) error {
 		file.Sync()
 	} else {
 		// Grace_Period line there, just replace it
+		replaced := strings.Replace(string(read), string(oldLine), newLine, -1)
+		err = ioutil.WriteFile(ganeshaConfig, []byte(replaced), 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setNumericOwners(ganeshaConfig string, numericOwners bool) error {
+	newLine := fmt.Sprintf("Only_Numeric_Owners = %v;", numericOwners)
+
+	re := regexp.MustCompile("Only_Numeric_Owners = (true|false);")
+
+	read, err := ioutil.ReadFile(ganeshaConfig)
+	if err != nil {
+		return err
+	}
+
+	oldLine := re.Find(read)
+
+	var file *os.File
+	if oldLine == nil {
+		// Only_Numeric_Owners line not there, append it after Grace_Period
+		re := regexp.MustCompile("Grace_Period = [0-9]+;")
+
+		gracePeriod := re.Find(read)
+
+		block := string(gracePeriod) + "\n" +
+			"\t" + newLine
+
+		replaced := strings.Replace(string(read), string(gracePeriod), block, -1)
+		err = ioutil.WriteFile(ganeshaConfig, []byte(replaced), 0)
+		if err != nil {
+			return err
+		}
+		file.Sync()
+	} else {
+		// Only_Numeric_Owners line there, just replace it
 		replaced := strings.Replace(string(read), string(oldLine), newLine, -1)
 		err = ioutil.WriteFile(ganeshaConfig, []byte(replaced), 0)
 		if err != nil {


### PR DESCRIPTION
NFS Ganesha supports disabling mapping IDs and instead using persistent UIDs which prevents issues with file ownership. These changes allow the provisioner to be configured in a way which can enable this option.